### PR TITLE
Phase 22.5 (#66): tick PRODUCTION.md reverse-proxy callout checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] — v0.3.1 (Keystone)
 
+### Docs — Phase 22.5: PRODUCTION.md reverse-proxy callout closed (#66)
+- The §3.5.1 "Reverse-proxy binding and the X-Forwarded-For trust model" callout was already drafted as part of the Phase 22 PRODUCTION.md rewrite; the roadmap checkbox is now ticked. The callout warns that exposing port 8080 directly to the public internet is unsafe until `get_client_ip()` extraction lands in v0.3.2 Phase 23.2 (issues #16 / #34 — admin allowlist hardened, four other XFF callsites still trust the header unconditionally).
+
 ### Added — Content block delete + duplicate-safe create
 - New `POST /admin/content/delete/<slug>` route + Delete button on each row of `/admin/content`. The button lives in a tiny POST form with a `confirm()` prompt so an accidental click still needs a second confirmation. Previously the only way to remove a block was raw SQL against the SQLite file — an obvious gap given the admin UI lets you create and edit them.
 - `POST /admin/content/new` now detects a duplicate slug (after normalising to lowercase + underscores). When a collision exists it flashes `A content block with slug "<slug>" already exists. Edit it instead.` and redirects to the edit form for that existing block, instead of silently no-op'ing via `INSERT OR IGNORE` and falsely flashing "Content block created."

--- a/ROADMAP_v0.3.1.md
+++ b/ROADMAP_v0.3.1.md
@@ -73,7 +73,7 @@ If v0.3.1 ships through its own gate cleanly, v0.3.2 and v0.3.3 each become "fix
 
 - [x] `compose.yaml` ports `"8080:8080"` binds `0.0.0.0` by default. Change to `"127.0.0.1:8080:8080"` so the container is only reachable through the reverse proxy on localhost.
 - [x] Same fix on the Quadlet `resume-site.container` `PublishPort=` line.
-- [ ] `docs/PRODUCTION.md` gains a loud callout in the "Reverse proxy" section: if you're exposing 8080 directly to the public internet, the X-Forwarded-For trust model the app ships with is unsafe (see #16 / #34). *(Handed off to Agent B — Phase 22 owner drafted the callout; see their PRODUCTION.md rewrite.)*
+- [x] `docs/PRODUCTION.md` gains a loud callout in the "Reverse proxy" section: if you're exposing 8080 directly to the public internet, the X-Forwarded-For trust model the app ships with is unsafe (see #16 / #34).
 
 ### 22.6 — Admin IP allowlist — don't trust X-Forwarded-For unconditionally (#16)
 


### PR DESCRIPTION
## Summary
- The §3.5.1 reverse-proxy / X-Forwarded-For trust-model callout was already drafted as part of the Phase 22 PRODUCTION.md rewrite — bookkeeping-only closure.
- Ticks the roadmap checkbox at `ROADMAP_v0.3.1.md:76` and drops the "Handed off to Agent B" parenthetical now that the work is closed.
- Adds a CHANGELOG entry under `[Unreleased] — v0.3.1 (Keystone)` noting the closure and cross-referencing #16 / #34.

## Test plan
- [x] Docs-only, manual visual review — verified §3.5.1 paragraph in `docs/PRODUCTION.md` warns against exposing port 8080 directly and references issues #16 / #34 (line 260 of the file).
- [x] Verified `simplify` skill criteria are non-applicable (docs-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)