### PR TITLE
Phase 36.6 (#18.11): observability runbook cross-reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Docs — Phase 22.5: PRODUCTION.md reverse-proxy callout closed (#66)
 - The §3.5.1 "Reverse-proxy binding and the X-Forwarded-For trust model" callout was already drafted as part of the Phase 22 PRODUCTION.md rewrite; the roadmap checkbox is now ticked. The callout warns that exposing port 8080 directly to the public internet is unsafe until `get_client_ip()` extraction lands in v0.3.2 Phase 23.2 (issues #16 / #34 — admin allowlist hardened, four other XFF callsites still trust the header unconditionally).
+### Documentation — Phase 36.6: observability runbook cross-reference (#18.11)
+
+- `docs/PRODUCTION.md` §7.3 now links to `docs/OBSERVABILITY_RUNBOOK.md` as a single coherent paragraph. The runbook covers the "when to reach for which tool" decision tree, the Prometheus + Grafana + Alertmanager wiring, and the synthetic-monitoring tiers. Closes the v0.3.0 Phase 18.11 carry-over: the anchor stub left for Agent C is now a live cross-reference. The `{#observability-runbook}` anchor is preserved so any external bookmarks still resolve.
 
 ### Added — Content block delete + duplicate-safe create
 - New `POST /admin/content/delete/<slug>` route + Delete button on each row of `/admin/content`. The button lives in a tiny POST form with a `confirm()` prompt so an accidental click still needs a second confirmation. Previously the only way to remove a block was raw SQL against the SQLite file — an obvious gap given the admin UI lets you create and edit them.

--- a/ROADMAP_v0.3.1.md
+++ b/ROADMAP_v0.3.1.md
@@ -125,7 +125,7 @@ If v0.3.1 ships through its own gate cleanly, v0.3.2 and v0.3.3 each become "fix
 
 ### 36.6 — Observability cross-reference (v0.3.0 Phase 18.11)
 
-- [ ] Add a one-line pointer from `docs/PRODUCTION.md` (monitoring section) to `docs/OBSERVABILITY_RUNBOOK.md`. Five-minute doc edit; flagged because v0.3.0 closed without it.
+- [x] Add a one-line pointer from `docs/PRODUCTION.md` (monitoring section) to `docs/OBSERVABILITY_RUNBOOK.md`. Five-minute doc edit; flagged because v0.3.0 closed without it.
 
 ### 36.7 — Subsystems as event-bus handlers (v0.3.0 Phase 19.1)
 

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -461,14 +461,7 @@ public internet.
 
 ### 7.3 Observability runbook cross-reference {#observability-runbook}
 
-<!-- ANCHOR: agent-c-observability-cross-ref (Phase 36.6).
-     Agent C: drop the one-line pointer to docs/OBSERVABILITY_RUNBOOK.md
-     here. Five-minute edit; section exists so the link has a stable
-     home (and so the v0.3.0 carry-over is visibly closed in this
-     file rather than left as an implicit "see §7"). -->
-
-_Reserved for Agent C's observability runbook pointer (Phase 36.6)._
-Until Agent C lands, the runbook lives at
+The full operator runbook lives at
 [`docs/OBSERVABILITY_RUNBOOK.md`](OBSERVABILITY_RUNBOOK.md) — the
 "when to reach for which tool" decision tree, the Prometheus +
 Grafana + Alertmanager wiring, and the synthetic-monitoring tiers.


### PR DESCRIPTION
## Summary

- Replace the placeholder + ANCHOR-comment block in `docs/PRODUCTION.md` §7.3 with a one-line cross-reference to `docs/OBSERVABILITY_RUNBOOK.md` (decision tree, Prometheus + Grafana + Alertmanager wiring, synthetic-monitoring tiers).
- Preserve the `{#observability-runbook}` anchor so any external bookmarks still resolve.
- Tick the roadmap checkbox at `ROADMAP_v0.3.1.md:128`; CHANGELOG entry under `[Unreleased]` v0.3.1 in a new "Documentation" subsection.

Closes the v0.3.0 Phase 18.11 carry-over.

## Test plan

- [x] docs-only, manual visual review — §7.3 renders as a single coherent paragraph
- [x] confirm `docs/OBSERVABILITY_RUNBOOK.md` exists at the link target
- [x] confirm the ANCHOR HTML comment is gone and the `{#observability-runbook}` anchor remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)