### PR TITLE
Phase 24.4 (#14): close bookkeeping + Server-header regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Security — Phase 24.4: `Server` / `X-Powered-By` header stripped (#14)
 
 - `after_request` handler now deletes the `Server` header (and any `X-Powered-By` a middleware might set) before the response goes out. Werkzeug / Gunicorn advertise their exact version by default, which hands an attacker the CVE list to try. The response shape is otherwise unchanged.
+- Multi-route regression test `test_no_server_header_on_any_route` in `tests/test_security.py` sweeps `/`, `/healthz`, `/readyz`, `/admin/login`, `/blog/` so a future regression in error handlers, health-check shortcuts, or admin-form rendering can't re-leak the header on a surface the original single-route test doesn't touch.
 
 ### Security — Phase 23.2: one `get_client_ip()` helper (#34)
 

--- a/ROADMAP_v0.3.2.md
+++ b/ROADMAP_v0.3.2.md
@@ -103,8 +103,8 @@ The new piece — **Phase 37, a formal API compatibility / deprecation policy** 
 
 ### 24.4 — `Server: gunicorn` header removal (#14)  [COMPLETED]
 
-- [ ] Strip or rewrite the `Server` response header. Two acceptable fixes: (a) set `app.after_request` to pop `Server` (simplest, works for any WSGI server); (b) document the Caddy `header Server "resume-site"` snippet in `docs/PRODUCTION.md` and recommend (a) as the belt inside the suspenders. Ship (a) in-tree.
-- [ ] Regression test: every route returns no `Server` header (or exactly the rewritten value).
+- [x] Strip or rewrite the `Server` response header. Two acceptable fixes: (a) set `app.after_request` to pop `Server` (simplest, works for any WSGI server); (b) document the Caddy `header Server "resume-site"` snippet in `docs/PRODUCTION.md` and recommend (a) as the belt inside the suspenders. Ship (a) in-tree.
+- [x] Regression test: every route returns no `Server` header (or exactly the rewritten value).
 
 ---
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1077,6 +1077,19 @@ def test_server_header_stripped_from_response(client):
     assert 'X-Powered-By' not in resp.headers
 
 
+def test_no_server_header_on_any_route(client):
+    """Phase 24.4 (#14): Server / X-Powered-By stripped from every response.
+
+    One path from each surface (public, health-check, admin-form, blog)
+    so a regression in error handlers, health-check shortcuts, or
+    admin-form rendering can't re-leak the header on a route the
+    single-route test above doesn't touch."""
+    for path in ('/', '/healthz', '/readyz', '/admin/login', '/blog/'):
+        resp = client.get(path)
+        assert 'Server' not in resp.headers, f'Server header leaked on {path}'
+        assert 'X-Powered-By' not in resp.headers, f'X-Powered-By leaked on {path}'
+
+
 # ============================================================
 # Phase 24.3 — log-injection hygiene (#22)
 # ============================================================


### PR DESCRIPTION
## Summary

- Tick the two checkboxes at `ROADMAP_v0.3.2.md:106-107` for Phase 24.4 (the heading was already marked `[COMPLETED]` but the bullets stayed empty).
- Add `test_no_server_header_on_any_route` in `tests/test_security.py` — sweeps `/`, `/healthz`, `/readyz`, `/admin/login`, `/blog/` to assert `Server` / `X-Powered-By` stripped on each surface (public, health-check, admin-form, blog). The existing single-route test only covered `/`, so a regression in error handlers, health-check shortcuts, or admin-form rendering could re-leak the header on routes that test doesn't touch.
- CHANGELOG entry under the existing Phase 24.4 Security section noting the multi-route regression test addition.

## Test plan

- [x] `python -m pytest tests/test_security.py::test_no_server_header_on_any_route -x` passes
- [x] `ruff check tests/test_security.py` — all checks passed
- [x] `ruff format --check tests/test_security.py` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)