### PR TITLE
Phase 37.1: API_COMPATIBILITY.md cross-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added — Phase 37.1: API compatibility policy doc
 
 - New `docs/API_COMPATIBILITY.md` — the stated contract between this codebase and any API / webhook consumer. Enumerates what MAY NOT change within a major version prefix (endpoints, field names, field types, error codes, event names, webhook envelope shape), what MAY change non-breakingly (new fields, new codes, new events, stricter validation), and the deprecation process every breaking change must go through (at minimum one release of `Deprecation`/`Sunset`/`Link` headers + CHANGELOG `Deprecated` entry + explicit removal release). Paired with the existing `docs/UPGRADE.md` which guarantees data survival; this doc closes the orthogonal consumer-contract gap.
+- Cross-references to `docs/API_COMPATIBILITY.md` added from `README.md` (Backup / REST API section), `docs/PRODUCTION.md` §9 (Upgrades), and a new `docs/API.md` stub that contextualises the OpenAPI spec — so a reader landing in any of the three entry points can find the compat contract without grepping.
 - Deferred to v0.3.3 or v0.4.0: the `@deprecated` decorator (37.2), OpenAPI spec drift guard (37.3), CHANGELOG-enforcement CI grep (37.4). The policy is the load-bearing piece; the plumbing lands as individual endpoints reach their first deprecation.
 
 ### Security — Phase 25.3: bounded webhook-dispatch thread pool (#47)

--- a/README.md
+++ b/README.md
@@ -372,6 +372,10 @@ mapped to the `resume-site-backups` named volume in both
 `compose.yaml` and the Quadlet unit). Inspect the host-side path with
 `podman volume inspect resume-site-backups`.
 
+For the formal compatibility / deprecation contract covering every
+`/api/v1/*` endpoint and the webhook envelope, see
+[`docs/API_COMPATIBILITY.md`](docs/API_COMPATIBILITY.md).
+
 #### Scheduled (systemd timer)
 
 For Quadlet / systemd deployments, the repository ships

--- a/ROADMAP_v0.3.2.md
+++ b/ROADMAP_v0.3.2.md
@@ -177,12 +177,12 @@ The new piece — **Phase 37, a formal API compatibility / deprecation policy** 
 
 ### 37.1 — `docs/API_COMPATIBILITY.md`  [COMPLETED]
 
-- [ ] New doc formalising the compat contract for every `/api/v1/*` endpoint and every webhook payload. Three sections:
+- [x] New doc formalising the compat contract for every `/api/v1/*` endpoint and every webhook payload. Three sections:
   - **Guaranteed stable within a major prefix (`/api/v1/`):** URL prefix, documented field names and types in the OpenAPI spec, webhook envelope shape (`event`, `timestamp`, `data` keys), error-code taxonomy, pagination envelope shape, HMAC signature algorithm, `Content-Language` / `Vary: Accept-Language` headers.
   - **Allowed to change within a major prefix (non-breaking):** addition of new fields (consumers must tolerate unknown keys), addition of new error codes (consumers must tolerate unknown codes), addition of new events, addition of new endpoints, tightening of input validation (always backward-compatible from a server perspective).
   - **Deprecation process:** field/endpoint flagged with `deprecated: true` in the OpenAPI spec for at least one full release; `Sunset` response header carries an RFC 3339 removal date at least one minor release in the future; `CHANGELOG.md` "Deprecated" section lists every such flag; removal only in the release named by the `Sunset` header, and only if the flag has been live for at least one prior release.
   - **Breaking change triggers a prefix bump:** `/api/v2/` only for genuinely breaking changes (field rename, type change, removed endpoint with no sunset notice, altered webhook envelope). `/api/v1/` continues to be served during a documented overlap window — minimum two minor releases.
-- [ ] Cross-references added to `README.md` (API section), `docs/PRODUCTION.md` (upgrade section), and `docs/API.md`.
+- [x] Cross-references added to `README.md` (API section), `docs/PRODUCTION.md` (upgrade section), and `docs/API.md`.
 
 ### 37.2 — `Sunset` / `Deprecation` HTTP headers
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,17 @@
+# API documentation
+
+resume-site exposes a versioned REST surface under `/api/v1/*` plus a
+webhook delivery envelope for outbound events. The endpoint reference
+itself — paths, methods, request and response schemas, error envelopes
+— lives in the OpenAPI spec at [`docs/openapi.yaml`](openapi.yaml)
+(interactively browsable at `/api/v1/docs` when `api_docs_enabled` is
+set in admin settings).
+
+For the stability contract that governs every endpoint and event in
+that spec — what MAY NOT change within `/api/v1/*`, what MAY change
+non-breakingly, and the deprecation process every breaking change
+must pass through — see
+[`docs/API_COMPATIBILITY.md`](API_COMPATIBILITY.md). For the
+operator-facing upgrade story (data survival, rollback, signature
+verification) see [`docs/UPGRADE.md`](UPGRADE.md) and
+[`docs/PRODUCTION.md`](PRODUCTION.md) §9.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -547,6 +547,12 @@ Every published image is cosign-signed via GitHub's OIDC identity
 was built by the resume-site CI workflow and hasn't been tampered
 with on the registry.
 
+[`docs/UPGRADE.md`](UPGRADE.md) covers data-survival across upgrades
+(migration reversibility, `pre-restore-*` sidecars, rolling-upgrade
+replay). For the orthogonal API-consumer contract — what stays stable
+across `/api/v1/*` and what triggers a `/api/v2/` prefix bump — see
+[`docs/API_COMPATIBILITY.md`](API_COMPATIBILITY.md).
+
 ---
 
 ## 10. Day-2 operations


### PR DESCRIPTION
## Summary

- Adds the three cross-references that the Phase 37.1 checklist required (the doc itself shipped, but `[ ]` items at `ROADMAP_v0.3.2.md:180` and `:185` stayed unchecked because the pointers were never wired up).
- `README.md` (Backup / REST API section) and `docs/PRODUCTION.md` §9 (Upgrades) get a one-line pointer to `docs/API_COMPATIBILITY.md`.
- New `docs/API.md` stub: a minimal landing doc that links out to `docs/openapi.yaml` (endpoint reference) and `docs/API_COMPATIBILITY.md` (stability contract). Doesn't recreate what the OpenAPI spec covers.
- Ticks the two checkboxes in `ROADMAP_v0.3.2.md` §37.1; CHANGELOG entry under `[Unreleased]` v0.3.2 extends the existing Phase 37.1 entry.

## Test plan

- [x] `ruff check .` still passes (no Python touched).
- [x] Docs-only, manual visual review: confirmed each new link target exists (`docs/API_COMPATIBILITY.md`, `docs/openapi.yaml`, `docs/UPGRADE.md`, `docs/PRODUCTION.md`).
- [x] Link text is descriptive (e.g. "the formal compatibility / deprecation contract", not "click here").
- [x] Inserted lines match the surrounding repo link style (`[\`docs/FILE.md\`](FILE.md)` form, relative paths correct for each file's location).

🤖 Generated with [Claude Code](https://claude.com/claude-code)