### PR TITLE
Phase 26.6 (#64): benchmark harness sets its own log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] — v0.3.3 (Proof)
 
+### Changed — Phase 26.6: benchmark harness sets its own log level (#64)
+
+- `scripts/benchmark_routes.py` now `os.environ.setdefault('RESUME_SITE_LOG_LEVEL', 'WARNING')` before importing app code, so contributors following the docstring no longer silently measure stderr-sink overhead. The startup banner prints the effective `RESUME_SITE_LOG_LEVEL` so an operator override (`RESUME_SITE_LOG_LEVEL=DEBUG python scripts/benchmark_routes.py`) is visible at a glance. Docstring rewritten — the script handles the default, operators only set the variable to override.
+
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 
 - The admin blog list previously rendered every row in one pass. Documented 8.3 ms at 150 posts, scaling linearly. The list route now wires up a new `get_all_posts_paginated` helper — default 25 posts/page, `?page=N` navigation, existing `?status=` filter preserved on paginator links so filter + page compose. Invalid `?page=` falls back to page 1.

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -72,8 +72,8 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 26.6 — Benchmark harness sets its own log level (#64)
 
-- [ ] `scripts/benchmark_routes.py` is documented to need `RESUME_SITE_LOG_LEVEL=WARNING`, but the script doesn't set it. Any contributor following the top-of-file docstring silently measures the stderr sink.
-- [ ] Have the script `os.environ.setdefault('RESUME_SITE_LOG_LEVEL', 'WARNING')` at import time, **before** importing `app`. Print the effective level in the banner so it's obvious if the operator overrode it.
+- [x] `scripts/benchmark_routes.py` is documented to need `RESUME_SITE_LOG_LEVEL=WARNING`, but the script doesn't set it. Any contributor following the top-of-file docstring silently measures the stderr sink.
+- [x] Have the script `os.environ.setdefault('RESUME_SITE_LOG_LEVEL', 'WARNING')` at import time, **before** importing `app`. Print the effective level in the banner so it's obvious if the operator overrode it.
 
 ---
 

--- a/scripts/benchmark_routes.py
+++ b/scripts/benchmark_routes.py
@@ -17,17 +17,27 @@ Notes:
       That's the number Phase 12.1 indexes and cache layer are supposed to
       keep stable across releases.
     * The first request per route is not timed (warm-up).
+    * The script defaults `RESUME_SITE_LOG_LEVEL=WARNING` so timings aren't
+      polluted by the stderr log sink; export the variable explicitly to
+      override (e.g. `RESUME_SITE_LOG_LEVEL=DEBUG` for diagnostics).
 """
 
 from __future__ import annotations
 
-import sqlite3
-import statistics
-import sys
-import tempfile
-import time
-from collections import Counter
-from pathlib import Path
+import os
+
+# Default the app log level to WARNING before importing app code so
+# benchmarks don't measure the stderr-sink overhead. setdefault honours
+# an operator override from the shell.
+os.environ.setdefault('RESUME_SITE_LOG_LEVEL', 'WARNING')
+
+import sqlite3  # noqa: E402
+import statistics  # noqa: E402
+import sys  # noqa: E402
+import tempfile  # noqa: E402
+import time  # noqa: E402
+from collections import Counter  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 # Allow running from anywhere
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -179,6 +189,10 @@ def _benchmark_route(client, path: str) -> dict:
 
 
 def main() -> int:
+    print(
+        f'effective RESUME_SITE_LOG_LEVEL={os.environ["RESUME_SITE_LOG_LEVEL"]}',
+        file=sys.stderr,
+    )
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
         config_path = _write_test_config(tmp_path)


### PR DESCRIPTION
## Summary

- `scripts/benchmark_routes.py` now defaults `RESUME_SITE_LOG_LEVEL=WARNING` before importing app code, so anyone following the docstring no longer silently measures stderr-sink overhead.
- Startup banner prints the effective `RESUME_SITE_LOG_LEVEL` so an operator override (`RESUME_SITE_LOG_LEVEL=DEBUG ...`) is visible at a glance.
- `os.environ.setdefault` honours an explicit shell override.
- Docstring rewritten — operators only set the variable to override; the script handles the default.

## Test plan

- [x] `python scripts/benchmark_routes.py` banner shows `effective RESUME_SITE_LOG_LEVEL=WARNING`.
- [x] `RESUME_SITE_LOG_LEVEL=ERROR python scripts/benchmark_routes.py` banner shows `ERROR` (override wins).
- [x] `ruff check scripts/benchmark_routes.py` passes.
- [x] `ruff format --check scripts/benchmark_routes.py` passes.

Roadmap: `ROADMAP_v0.3.3.md:75-76` ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)