### PR TITLE
Phase 28.2 (#30): un-advisory vulture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,11 @@ jobs:
         run: bandit -r app/ -c pyproject.toml -ll
 
       - name: Vulture dead code detection
+        # Phase 28.2 — blocking. Surviving findings either get the
+        # vulture_allowlist.py entry (with a one-line rationale) or the
+        # code deletion they deserve. The matching pre-commit hook
+        # catches this locally before push.
         run: vulture app/ manage.py vulture_allowlist.py --min-confidence 80
-        continue-on-error: true  # Advisory — ratchet to blocking in v0.4.0
 
       - name: Check for unsafe SQL patterns
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,21 @@ repos:
         pass_filenames: false
 
   # ----------------------------------------------------------------
+  # vulture — dead code detection (Phase 28.2)
+  # Mirrors the CI invocation; runs on the same paths and confidence.
+  # Findings either get a vulture_allowlist.py entry or the deletion
+  # they deserve. False-negatives (real dead code that vulture missed)
+  # are preferred to false-positives (live code flagged dead) at this
+  # confidence threshold.
+  # ----------------------------------------------------------------
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: v2.16
+    hooks:
+      - id: vulture
+        args: ['app/', 'manage.py', 'vulture_allowlist.py', '--min-confidence', '80']
+        pass_filenames: false
+
+  # ----------------------------------------------------------------
   # detect-secrets — catch credentials before they hit git history
   # ----------------------------------------------------------------
   - repo: https://github.com/Yelp/detect-secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The "Check for unsafe SQL patterns" step in `.github/workflows/ci.yml` previously suppressed lines tagged `# nosec B608` (bandit) but not `# noqa: S608` (ruff/flake8-bandit). Every intentional interpolation in this codebase carries both annotations, so the bug had no false-positives in tree — but a future contributor who used only the ruff annotation would have been silently un-checked. The `grep -v` filter now matches either annotation via `grep -vE 'nosec B608|noqa: S608'`. The error message points to both styles.
 - New `tests/test_ci_guards.py` with seven regression tests that shell out to `grep` against `tmp_path` fixtures and lock the suppression contract: bare interpolations fire, `nosec`-only suppresses, `noqa`-only suppresses (Phase 28.1 acceptance test), both together suppress, and the `.format()` half of the guard honours both annotations identically.
+### CI — Phase 28.2: un-advisory `vulture` (#30)
+
+- The `quality` job's vulture step is now blocking instead of advisory. `continue-on-error: true` removed; any new dead-code finding at `--min-confidence 80` fails the build. Current tree is already clean at that threshold, so the flip lands without code deletions or new allowlist entries.
+- Matching pre-commit hook added (`https://github.com/jendrikseipp/vulture` v2.16) with the same paths and confidence as CI, so contributors catch findings before push. `CONTRIBUTING.md` documents the workflow: real dead code gets deleted, runtime-dispatched callables (Flask url_map handlers, reflection-invoked methods) get a single-line `vulture_allowlist.py` entry with an inline rationale.
 
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ Thanks for your interest in contributing to resume-site.
 - Follow existing code style (PEP 8, 120 char line length).
 - Don't commit `config.yaml`, database files, or personal photos — these are gitignored for a reason.
 
+## Dead-code detection (v0.3.3+)
+
+Dead-code detection (`vulture`) is now blocking in CI. Run `vulture app/ manage.py vulture_allowlist.py --min-confidence 80` locally before committing — the pre-commit hook does this automatically. If vulture flags a runtime-dispatched callable (Flask route handler hit only via the URL map, a method invoked by reflection, etc.), add a single-line entry to `vulture_allowlist.py` with an inline comment explaining why the finding is a false positive. Truly dead code should be deleted, not allowlisted.
+
 ## Container Image Changes (v0.3.0+)
 
 If your PR touches `Containerfile`, `requirements.txt`, or anything that ends up baked into the runtime image:

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -88,8 +88,8 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 28.2 — Un-advisory `vulture` (#30)
 
-- [ ] CI vulture step is `continue-on-error: true`. Flip to blocking. Any currently-surviving findings either get the allowlist entry or the code deletion they deserve.
-- [ ] Pre-commit hook added (matches CI). `CONTRIBUTING.md` updated.
+- [x] CI vulture step is `continue-on-error: true`. Flip to blocking. Any currently-surviving findings either get the allowlist entry or the code deletion they deserve.
+- [x] Pre-commit hook added (matches CI). `CONTRIBUTING.md` updated.
 
 ### 28.3 — Fix or retire `upgrade-simulation` (#31)
 


### PR DESCRIPTION
## Summary

- Flip the `quality` job's `vulture` step from advisory to blocking — `continue-on-error: true` removed. Tree is already clean at `--min-confidence 80`, so no code deletions or new allowlist entries are needed for the flip itself.
- Add a matching pre-commit hook (`jendrikseipp/vulture` v2.16) using the same paths and confidence as CI, so contributors catch findings before push.
- Document the workflow in `CONTRIBUTING.md`: real dead code gets deleted, runtime-dispatched callables (Flask url_map handlers, reflection-invoked methods) get a single-line `vulture_allowlist.py` entry with an inline rationale.
- Tick `ROADMAP_v0.3.3.md` Phase 28.2; CHANGELOG `[Unreleased] v0.3.3` gets a `### CI` entry.

## Test plan

- [x] `vulture app/ manage.py vulture_allowlist.py --min-confidence 80` — exit 0, zero findings.
- [x] `pre-commit run --all-files vulture` — Passed.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses.
- [x] `python -c "import yaml; yaml.safe_load(open('.pre-commit-config.yaml'))"` — parses.
- [ ] CI green on this PR — confirms the flipped vulture step is actually blocking and the rest of `quality` is still happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)