### PR TITLE
Phase 28.1 (#29): SQL grep guard accepts noqa: S608 too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,16 @@ jobs:
         run: |
           # Catch string formatting in SQL queries (f-strings, .format, %).
           # Parameterized queries use ? placeholders, never interpolation.
-          # Annotated safe cases (`# nosec B608`) are filtered out — those
-          # already went through bandit's explicit review with an inline
-          # justification. Anything unannotated is a real finding.
-          if grep -rn "execute(f['\"]" app/ | grep -v 'nosec B608' \
-             || grep -rn '\.format(' app/ | grep -i 'execute\|select\|insert\|update\|delete' | grep -v 'nosec B608'; then
+          # Annotated safe cases are filtered out — those already went
+          # through explicit review with an inline justification. Either
+          # `# nosec B608` (bandit) or `# noqa: S608` (ruff/flake8-bandit)
+          # is accepted; in this codebase intentional interpolations
+          # carry both, but a single annotation is enough to suppress
+          # the guard. Anything unannotated is a real finding.
+          if grep -rn "execute(f['\"]" app/ | grep -vE 'nosec B608|noqa: S608' \
+             || grep -rn '\.format(' app/ | grep -i 'execute\|select\|insert\|update\|delete' | grep -vE 'nosec B608|noqa: S608'; then
             echo "ERROR: Found string interpolation in SQL queries. Use parameterized queries (?) instead."
-            echo "If the interpolation is safe (hardcoded table/column names), annotate with '# nosec B608 — reason'."
+            echo "If the interpolation is safe (hardcoded table/column names), annotate with '# nosec B608 — reason' and/or '# noqa: S608'."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrated three services to the helper: `update_webhook` (was already partial-update; allowlist now lives next to its column constant), `update_service`, and `update_stat` (both converted from always-update to partial-update). The other `update_*` functions in `app/services/` (`update_post`, `update_review_tier`) carry one-off quirks — slug regeneration, derived `reading_time`, format-conditional sanitisation — so they're tracked for follow-up rather than force-fit.
 - 12 helper tests in `tests/test_crud.py` cover single- and multi-column updates, allowlist rejection, validation rollback, activity-log emission/skip, concurrent-writer lock contention with a clean rollback on the loser, and the row-not-found return-zero path. The `test_services_edit` and `test_stats_edit` admin tests were strengthened to assert DB persistence (the `feedback_admin_route_coverage.md` pattern — render-only redirect checks let an ImportError ship in v0.3.1).
 ### Deprecated
+### CI — Phase 28.1: SQL grep guard accepts `# noqa: S608` too (#29)
+
+- The "Check for unsafe SQL patterns" step in `.github/workflows/ci.yml` previously suppressed lines tagged `# nosec B608` (bandit) but not `# noqa: S608` (ruff/flake8-bandit). Every intentional interpolation in this codebase carries both annotations, so the bug had no false-positives in tree — but a future contributor who used only the ruff annotation would have been silently un-checked. The `grep -v` filter now matches either annotation via `grep -vE 'nosec B608|noqa: S608'`. The error message points to both styles.
+- New `tests/test_ci_guards.py` with seven regression tests that shell out to `grep` against `tmp_path` fixtures and lock the suppression contract: bare interpolations fire, `nosec`-only suppresses, `noqa`-only suppresses (Phase 28.1 acceptance test), both together suppress, and the `.format()` half of the guard honours both annotations identically.
 
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -83,8 +83,8 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 28.1 — Fix the SQL-interpolation grep guard (#29)
 
-- [ ] `.github/workflows/ci.yml` greps for `nosec B608` but not `noqa: S608`. Every intentional interpolation in the codebase carries **both** annotations; the CI grep is therefore false-negative for any new interpolation that only carries `noqa`.
-- [ ] Update the grep to treat either annotation as an accepted suppression. Better still, replace the fragile grep with a ruff custom rule or a dedicated bandit invocation scoped to `app/` that already understands both annotation styles.
+- [x] `.github/workflows/ci.yml` greps for `nosec B608` but not `noqa: S608`. Every intentional interpolation in the codebase carries **both** annotations; the CI grep is therefore false-negative for any new interpolation that only carries `noqa`.
+- [x] Update the grep to treat either annotation as an accepted suppression. (The fancier rewrite — ruff custom rule or dedicated bandit invocation — is logged as a follow-up; the simpler grep fix lands here.) Regression-locked by `tests/test_ci_guards.py`.
 
 ### 28.2 — Un-advisory `vulture` (#30)
 

--- a/tests/test_ci_guards.py
+++ b/tests/test_ci_guards.py
@@ -1,0 +1,129 @@
+"""
+Regression tests for the CI shell guards in ``.github/workflows/ci.yml``.
+
+These tests don't run the GitHub Actions runner — they shell out to ``grep``
+with the same expression CI uses and assert it suppresses / fires on the
+right lines. Any change to the guard expression in the workflow file must
+be mirrored here so the suppression list stays in lock-step with reality.
+
+Phase 28.1 (#29) — the guard now treats both ``# nosec B608`` and
+``# noqa: S608`` as accepted suppressions. Either annotation alone is
+enough; in practice intentional interpolations in this repo carry both,
+but the guard does not require it.
+"""
+
+import subprocess
+
+# The exact ``grep -v`` filter the CI workflow uses. If you change the
+# regex in ``.github/workflows/ci.yml``, change it here too — these
+# tests are the contract.
+_SUPPRESSION_REGEX = 'nosec B608|noqa: S608'
+
+
+def _grep(args, stdin=None):
+    """Run ``grep ARGS`` (optionally piping stdin); return stdout.
+
+    S603/S607 are bandit warnings about generic subprocess use; neither
+    applies here. The argument list is hardcoded ``grep`` flags + paths
+    inside ``tmp_path`` we just wrote, and ``grep`` on PATH is a safe
+    assumption in any test environment (CI image, dev workstation).
+    """
+    return subprocess.run(  # noqa: S603
+        ['grep', *args],  # noqa: S607 — grep on PATH is safe in test env.
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+
+
+def _run_guard(scan_dir):
+    """
+    Run the f-string + .format() halves of the CI guard against a directory.
+
+    Returns the combined stdout. Empty stdout = the guard is clean (no
+    findings); non-empty stdout = the guard would fail CI.
+    """
+    fstring_hits = _grep(['-rn', 'execute(f[\'"]', str(scan_dir)])
+    fstring_findings = _grep(['-vE', _SUPPRESSION_REGEX], stdin=fstring_hits)
+
+    format_hits = _grep(['-rn', r'\.format(', str(scan_dir)])
+    format_keyworded = _grep(
+        ['-i', 'execute\\|select\\|insert\\|update\\|delete'], stdin=format_hits
+    )
+    format_findings = _grep(['-vE', _SUPPRESSION_REGEX], stdin=format_keyworded)
+
+    return fstring_findings + format_findings
+
+
+def test_unannotated_fstring_is_flagged(tmp_path):
+    """An f-string SQL execute with no annotation should fire the guard."""
+    sample = tmp_path / 'unsafe.py'
+    sample.write_text("db.execute(f'SELECT * FROM {table}')\n")
+    output = _run_guard(tmp_path)
+    assert 'unsafe.py' in output, f'Bare f-string execute should fire the guard: {output!r}'
+
+
+def test_nosec_only_suppresses(tmp_path):
+    """A line carrying only ``# nosec B608`` is accepted (legacy style)."""
+    sample = tmp_path / 'nosec_only.py'
+    sample.write_text("db.execute(f'SELECT * FROM {table}')  # nosec B608 — table from allowlist\n")
+    output = _run_guard(tmp_path)
+    assert output == '', f'`# nosec B608` alone should suppress the guard, got: {output!r}'
+
+
+def test_noqa_only_suppresses(tmp_path):
+    """
+    A line carrying only ``# noqa: S608`` is accepted (Phase 28.1 fix).
+
+    Before the fix the guard only filtered out ``nosec B608``; a future
+    contributor who used the ruff/flake8-bandit annotation alone was
+    silently un-checked. This is the test that locks the new behaviour.
+    """
+    sample = tmp_path / 'noqa_only.py'
+    sample.write_text("db.execute(f'SELECT * FROM {table}')  # noqa: S608\n")
+    output = _run_guard(tmp_path)
+    assert output == '', f'`# noqa: S608` alone should suppress the guard, got: {output!r}'
+
+
+def test_both_annotations_suppresses(tmp_path):
+    """The repo's existing convention (both annotations) keeps working."""
+    sample = tmp_path / 'both.py'
+    sample.write_text("db.execute(f'SELECT * FROM {table}')  # noqa: S608  # nosec B608\n")
+    output = _run_guard(tmp_path)
+    assert output == '', f'Both annotations together should suppress the guard, got: {output!r}'
+
+
+def test_format_with_select_keyword_is_flagged(tmp_path):
+    """A bare ``.format()`` call near a SQL keyword fires the guard."""
+    sample = tmp_path / 'format_unsafe.py'
+    sample.write_text("query = 'SELECT * FROM {}'.format(table)\ndb.execute(query)\n")
+    output = _run_guard(tmp_path)
+    assert 'format_unsafe.py' in output, (
+        f'Unannotated .format() with SELECT keyword should fire: {output!r}'
+    )
+
+
+def test_format_with_noqa_is_suppressed(tmp_path):
+    """The ``.format()`` half of the guard also honours ``# noqa: S608``."""
+    sample = tmp_path / 'format_noqa.py'
+    sample.write_text("query = 'SELECT * FROM {}'.format(table)  # noqa: S608\n")
+    output = _run_guard(tmp_path)
+    assert output == '', f'`# noqa: S608` should suppress the .format() half too, got: {output!r}'
+
+
+def test_mixed_annotations_in_one_tree(tmp_path):
+    """One annotated file, one bare file: the guard fires on exactly the bare one."""
+    safe = tmp_path / 'reviewed.py'
+    safe.write_text(
+        'def a():\n'
+        "    db.execute(f'SELECT * FROM {t}')  # noqa: S608\n"
+        'def b():\n'
+        "    db.execute(f'INSERT INTO {t} VALUES (?)', (v,))  # nosec B608\n"
+    )
+    unsafe = tmp_path / 'bare.py'
+    unsafe.write_text("db.execute(f'DELETE FROM {t}')\n")
+
+    output = _run_guard(tmp_path)
+    assert 'bare.py' in output
+    assert 'reviewed.py' not in output


### PR DESCRIPTION
## Summary

- The `quality` job's "Check for unsafe SQL patterns" step previously suppressed `# nosec B608` (bandit) but not `# noqa: S608` (ruff/flake8-bandit). Every intentional interpolation in this codebase carries both annotations, so the bug had no false-positives in tree — but a future contributor using only the ruff style would have been silently un-checked.
- Both halves of the guard (f-string `execute(f...)` and `.format()` near a SQL keyword) now filter via `grep -vE 'nosec B608|noqa: S608'`. Error message updated to point to both styles.
- New `tests/test_ci_guards.py` regression-locks the suppression contract: bare interpolations fire, `nosec`-only suppresses, `noqa`-only suppresses (the acceptance test for this fix), both annotations together suppress, and the `.format()` half honours both styles identically (7 tests, all green).

The roadmap option of replacing the grep with a ruff custom rule or a dedicated bandit invocation is logged as follow-up tech debt — the simpler grep fix lands here.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — workflow YAML still parses cleanly.
- [x] Manual e2e: create `/tmp/sql_test_dir/sample.py` with `db.execute(f"SELECT * FROM {table}")  # noqa: S608`, run the updated guard pipeline against it — no flag (PASS). Add `bare.py` with no annotation — flagged (PASS).
- [x] `python -m pytest tests/test_ci_guards.py -v` — 7 passed in 0.13s.
- [x] `ruff check . && ruff format --check .` — all checks passed; 108 files already formatted.
- [x] Real-tree regression: `grep -rn "execute(f['\"]" app/ | grep -vE 'nosec B608|noqa: S608'` produces no output — guard does not fire against the existing `app/` tree.

CHANGELOG `[Unreleased]` v0.3.3 entry added under "### CI"; `ROADMAP_v0.3.3.md:86-87` checkboxes ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)