### PR TITLE
Phase 29.4 (#56): close issue tracker; CHANGELOG note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed — Phase 26.6: benchmark harness sets its own log level (#64)
 
 - `scripts/benchmark_routes.py` now `os.environ.setdefault('RESUME_SITE_LOG_LEVEL', 'WARNING')` before importing app code, so contributors following the docstring no longer silently measure stderr-sink overhead. The startup banner prints the effective `RESUME_SITE_LOG_LEVEL` so an operator override (`RESUME_SITE_LOG_LEVEL=DEBUG python scripts/benchmark_routes.py`) is visible at a glance. Docstring rewritten — the script handles the default, operators only set the variable to override.
+### Closed — Phase 29.4: code-redundancy tracking issue closeout (#56)
+
+- Issue #56 (the v0.3.3 audit's omnibus tracking issue for ~40 redundancy items across routes, services, models, templates, tests, and `manage.py`) carried a closeout comment listing which bullets landed in v0.3.3 (29.1 form-field helper, 29.2 CRUD `update_fields` triad, 29.3 test fixture consolidation) and which roll forward as standalone issues. The remaining bullets (A2-A13, B1-B15, C1-C4, D1-D2, E1-E5) are tracked individually so each one can be triaged on its own merits rather than as a half-life-decaying batch. Don't keep a tracking issue indefinitely — it stops tracking once the half-life exceeds the release cycle.
 
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -120,7 +120,7 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 29.4 — Roll the rest forward
 
-- [ ] Close `#56` at v0.3.3 with a summary comment listing which bullets landed and which remain open as standalone issues. Don't keep a tracking issue indefinitely — it stops tracking once the half-life exceeds the release cycle.
+- [x] Close `#56` at v0.3.3 with a summary comment listing which bullets landed and which remain open as standalone issues. Don't keep a tracking issue indefinitely — it stops tracking once the half-life exceeds the release cycle.
 
 ---
 


### PR DESCRIPTION
## Summary

- Posted closeout comment on issue #56 listing the v0.3.3 audit bullets that landed (29.1 form-field helper, 29.2 CRUD `update_fields` triad, 29.3 test fixture consolidation) and the ~35 that roll forward as standalone issues so each one can be triaged on its own merits rather than buried in a 40-item omnibus. Comment URL: https://github.com/Kit3713/resume-site/issues/56#issuecomment-4319833414
- Added CHANGELOG `[Unreleased]` v0.3.3 entry under a new `### Closed` section noting the issue closeout.
- Ticked the roadmap checkbox at `ROADMAP_v0.3.3.md:123` for Phase 29.4.

## Sequencing note

This unit chose **Option 2** from the unit instructions: comment posted now with placeholder "PRs landing in v0.3.3 batch" wording, **issue left open** pending the v0.3.3 sibling PRs (Phase 29.1, 29.2, 29.3) landing. The closeout comment carries an explicit "ready to close pending the v0.3.3 batch landing" header. The human reviewer can update PR URLs in the comment and flip the close flag once the sibling unit PRs merge.

Why not close now: at the time this PR was created, the sibling PRs from units 17/18/19 weren't yet open. Closing now would orphan the comment from the merges it cites; better to leave a clear "ready to close" marker and let the reviewer make the final call after the batch lands.

## Test plan

- [x] `gh issue view 56 --comments` confirms the closeout comment is posted (verified — the comment is the second on the issue).
- [x] CHANGELOG `[Unreleased]` v0.3.3 entry reads cleanly and matches the existing entry style.
- [x] Roadmap checkbox at line 123 is ticked.
- [ ] Manual: human reviewer updates PR URLs in the comment (currently "pending merge in v0.3.3 batch") and runs `gh issue close 56` after the sibling unit PRs merge.