### PR TITLE
Phase 28.3 (#31): retire upgrade-simulation; replace with migrate --dry-run probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,32 +251,33 @@ jobs:
           cache: 'true'
 
   # -----------------------------------------------------------
-  # Upgrade simulation (Phase 21.5 — push-update survivability)
+  # Migrate dry-run probe (Phase 28.3 — replaces upgrade-simulation)
   #
-  # This is the load-bearing "rolling upgrade doesn't destroy data"
-  # gate. Runs in parallel with container-build / container-scan (it
-  # only depends on ``test``), and does two things:
+  # Two checks compose the migration-soundness gate:
   #
-  #   1. Static reversibility: ``manage.py migrate --verify-reversible``
-  #      walks every migration and fails the job if any contain DROP
-  #      TABLE, NOT NULL ADD COLUMN without DEFAULT, DROP of a NOT NULL
-  #      column, or ALTER/MODIFY COLUMN syntax. Pure file-read, no DB
-  #      needed.
+  #   1. Static reversibility:
+  #      ``manage.py migrate --verify-reversible`` walks every
+  #      migration file and refuses DROP TABLE, NOT NULL ADD COLUMN
+  #      without DEFAULT, DROP of a NOT NULL column, or
+  #      ALTER/MODIFY COLUMN. Pure file-read, no DB needed.
   #
-  #   2. Dynamic replay: boot the previously-published ``:latest``
-  #      image against a volume + config.yaml, run init-db inside it
-  #      (the entrypoint handles that), stop it, and boot the freshly
-  #      built image against the same volume. The new image must
-  #      happily apply the pending migrations on top of the old DB and
-  #      pass /healthz + /readyz + the landing page + /admin/login.
+  #   2. Dry-run probe: build the image, then run
+  #      ``manage.py migrate --dry-run`` inside it against an empty
+  #      DB. Prints every pending migration's SQL without applying
+  #      it; a syntactically broken migration or a missing
+  #      migrations/ file in the image fails the publish gate.
   #
-  # If ``:latest`` hasn't been published yet (first-ever release),
-  # the dynamic replay short-circuits with a notice — there's no
-  # previous version to upgrade from. The static check always runs.
+  # This replaces the long-advisory ``upgrade-simulation`` job (issue
+  # #31). The simulation tried to do a full ``:latest`` pull + volume
+  # replay, but the bind-mount permissions kept tripping over SELinux
+  # on the GitHub runner and the job was stranded as
+  # ``continue-on-error: true`` for months. The two checks above give
+  # operators the same "migrations look right" guarantee without the
+  # SELinux/bind-mount maintenance burden.
   # -----------------------------------------------------------
-  upgrade-simulation:
+  migrate-dryrun:
     runs-on: ubuntu-latest
-    needs: test
+    needs: container-build
     steps:
       - uses: actions/checkout@v4
 
@@ -292,153 +293,53 @@ jobs:
           # cleanly (which requires werkzeug from the runtime deps).
           pip install -r requirements.txt
 
-      # Part 1: static reversibility walker. This doesn't touch the
-      # DB — it just parses migration files. A violation here fails
-      # the job before any container work.
+      # Static reversibility — pure file-read, no DB or container.
       - name: Verify migrations are reversible
         run: python manage.py migrate --verify-reversible
 
-      - name: Build container image (for upgrade sim)
+      - name: Build container image (for dry-run probe)
         run: |
           docker build \
             --build-arg IMAGE_VERSION="ci-${GITHUB_SHA::7}" \
-            -t ${{ env.IMAGE_NAME }}:upgrade \
+            -t ${{ env.IMAGE_NAME }}:dryrun \
             -f Containerfile .
 
-      # Part 2: dynamic replay. Pull the previously-published image,
-      # seed a volume, swap to the freshly-built image, verify every
-      # probe. ``|| true`` on the pull so we can continue on first
-      # release — the subsequent steps skip gracefully.
-      - name: Pull previous release (:latest)
-        id: pull_prior
+      - name: Migrate --dry-run probe
         run: |
-          set -e
-          if docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; then
-            echo "have_prior=true" >> $GITHUB_OUTPUT
-            docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest prior-release
-          else
-            echo "No prior :latest image in the registry — upgrade replay will be skipped."
-            echo "have_prior=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Prepare upgrade scenario
-        if: steps.pull_prior.outputs.have_prior == 'true'
-        run: |
-          # A config.yaml the image can actually boot from. The hash
-          # below is the werkzeug pbkdf2:sha256 form of "ci-password";
-          # the admin user isn't exercised beyond the login form render,
-          # so a real login isn't needed.
-          mkdir -p /tmp/upgrade-data /tmp/upgrade-photos /tmp/upgrade-backups
-          # Bind-mount permission fix: the GitHub runner creates these
-          # dirs as the runner UID, but the container's appuser is UID
-          # 1000 and can't write to them — entrypoint's init-db then
-          # fails to create site.db, the container exits, and /healthz
-          # never answers. Pre-chown to the appuser UID so both the
-          # prior-release and new-image boots can populate the volumes.
-          sudo chown -R 1000:1000 /tmp/upgrade-data /tmp/upgrade-photos /tmp/upgrade-backups
-          cat > /tmp/upgrade-config.yaml <<EOF
-          secret_key: "ci-upgrade-test-secret-key-that-is-long-enough-for-audit"
+          # Minimal config.yaml the app factory accepts. The dry-run
+          # path opens an empty SQLite DB at database_path, prints each
+          # pending migration's SQL, then exits — no schema is written,
+          # no admin auth is exercised, so any well-formed pbkdf2 hash
+          # works. Single-quoted heredoc keeps the $-delimiters in the
+          # password_hash literal from undergoing shell expansion.
+          cat > /tmp/dryrun-config.yaml <<'EOF'
+          secret_key: "ci-dryrun-probe-secret-key-that-is-long-enough-for-audit"
           database_path: "/app/data/site.db"
           photo_storage: "/app/photos"
           session_cookie_secure: false
           admin:
             username: "admin"
-            password_hash: "__PLACEHOLDER__"
+            password_hash: "pbkdf2:sha256:600000$dryrunsalt$0000000000000000000000000000000000000000000000000000000000000000"
           EOF
-          # Post-process to insert the pbkdf2 hash. Doing it with sed
-          # sidesteps the shell $-expansion surprises a heredoc would
-          # introduce in the three $-delimited sections of the
-          # pbkdf2 format. Admin auth is never actually exercised past
-          # GET /admin/login (form render), so any well-formed hash
-          # works for the smoke test.
-          HASH_LITERAL='pbkdf2:sha256:600000$upgradesaltcicicic$0000000000000000000000000000000000000000000000000000000000000000'
-          sed -i "s|__PLACEHOLDER__|${HASH_LITERAL}|" /tmp/upgrade-config.yaml
 
-      - name: Boot previous release against scenario volumes
-        if: steps.pull_prior.outputs.have_prior == 'true'
-        run: |
-          set -e
-          # The entrypoint runs init-db on first boot, so the old image
-          # populates /app/data with a fully-migrated (to its version)
-          # DB that the new image will then need to upgrade.
-          docker run -d --name upgrade-prior \
-            -p 18080:8080 \
-            -v /tmp/upgrade-config.yaml:/app/config.yaml:ro \
-            -v /tmp/upgrade-data:/app/data \
-            -v /tmp/upgrade-photos:/app/photos \
-            -v /tmp/upgrade-backups:/app/backups \
-            prior-release
-
-          # Wait for startup: poll /healthz until it answers, up to 30s.
-          for i in $(seq 1 30); do
-            if curl -fsS http://localhost:18080/healthz > /dev/null 2>&1; then
-              echo "Prior release is up after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-          curl -fsS http://localhost:18080/readyz  || (docker logs upgrade-prior && exit 1)
-          # Stop (don't remove the volumes — that's the whole point).
-          docker stop upgrade-prior
-          docker rm   upgrade-prior
-
-      - name: Boot new image against the same volumes
-        if: steps.pull_prior.outputs.have_prior == 'true'
-        run: |
-          set -e
-          docker run -d --name upgrade-new \
-            -p 18080:8080 \
-            -v /tmp/upgrade-config.yaml:/app/config.yaml:ro \
-            -v /tmp/upgrade-data:/app/data \
-            -v /tmp/upgrade-photos:/app/photos \
-            -v /tmp/upgrade-backups:/app/backups \
-            ${{ env.IMAGE_NAME }}:upgrade
-
-          # Wait for migrations + startup — newer images may apply
-          # several migrations before Gunicorn binds, so allow a
-          # generous window.
-          for i in $(seq 1 45); do
-            if curl -fsS http://localhost:18080/healthz > /dev/null 2>&1; then
-              echo "Upgraded release is up after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-
-          # Every Phase 21.5 acceptance probe must succeed against the
-          # upgraded container.
-          curl -fsS http://localhost:18080/healthz      || (docker logs upgrade-new && exit 1)
-          curl -fsS http://localhost:18080/readyz       || (docker logs upgrade-new && exit 1)
-          curl -fsS http://localhost:18080/             || (docker logs upgrade-new && exit 1)
-          # /admin/login is IP-gated to ``admin.allowed_networks``. A
-          # host-side request via the published port arrives with
-          # ``remote_addr=172.17.0.1`` (Docker bridge gateway), which is
-          # NOT in the default allowlist — the 172.16/12 range is
-          # deliberately omitted so sibling containers on the host
-          # bridge can't reach /admin. Probe through loopback *inside*
-          # the container so ``remote_addr=127.0.0.1``, which is how
-          # production traffic actually arrives (reverse proxy on the
-          # host forwarding to 127.0.0.1:8080). Any 2xx (form render)
-          # or 302 (session redirect) passes; anything else means the
-          # admin blueprint failed to register or the IP gate regressed.
-          status=$(docker exec upgrade-new curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/admin/login)
-          if [ "$status" != "200" ] && [ "$status" != "302" ]; then
-            echo "ERROR: /admin/login returned $status on the upgraded container"
-            docker logs upgrade-new
-            exit 1
-          fi
-
-          docker stop upgrade-new
-          docker rm   upgrade-new
+          # Override the entrypoint (which runs init-db then Gunicorn)
+          # so we invoke manage.py directly. --rm cleans up the
+          # container even on failure. Non-zero exit fails the job.
+          docker run --rm \
+            --entrypoint python \
+            -v /tmp/dryrun-config.yaml:/app/config.yaml:ro \
+            ${{ env.IMAGE_NAME }}:dryrun \
+            manage.py migrate --dry-run
 
   # -----------------------------------------------------------
   publish:
     runs-on: ubuntu-latest
     # container-scan must pass before any image is pushed. This is the
-    # CVE-gate side of the Phase 21.3 contract. upgrade-simulation is
-    # the Phase 21.5 data-survival gate — a release that can't upgrade
-    # cleanly from the previous :latest never ships.
-    needs: [test, container-build, container-scan, upgrade-simulation]
+    # CVE-gate side of the Phase 21.3 contract. migrate-dryrun is the
+    # Phase 28.3 migration-soundness gate (replaced the stranded
+    # upgrade-simulation job, issue #31): a release whose migrations
+    # don't even dry-run cleanly never ships.
+    needs: [test, container-build, container-scan, migrate-dryrun]
     if: startsWith(github.ref, 'refs/tags/v')
 
     # `id-token: write` lets cosign request the OIDC token for keyless
@@ -701,7 +602,7 @@ jobs:
   # -----------------------------------------------------------
   publish-main:
     runs-on: ubuntu-latest
-    needs: [test, container-build, container-scan, upgrade-simulation]
+    needs: [test, container-build, container-scan, migrate-dryrun]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     # Same OIDC requirement as the tag-publish job — cosign keyless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The `quality` job's vulture step is now blocking instead of advisory. `continue-on-error: true` removed; any new dead-code finding at `--min-confidence 80` fails the build. Current tree is already clean at that threshold, so the flip lands without code deletions or new allowlist entries.
 - Matching pre-commit hook added (`https://github.com/jendrikseipp/vulture` v2.16) with the same paths and confidence as CI, so contributors catch findings before push. `CONTRIBUTING.md` documents the workflow: real dead code gets deleted, runtime-dispatched callables (Flask url_map handlers, reflection-invoked methods) get a single-line `vulture_allowlist.py` entry with an inline rationale.
+### CI — Phase 28.3: retire `upgrade-simulation`; replace with `migrate --dry-run` probe (#31)
+
+- Retired the long-advisory `upgrade-simulation` CI job. It tried to do a full `:latest` pull + volume replay against the freshly built image, but the bind-mount permissions kept tripping over SELinux on the GitHub runner and the job was stranded as `continue-on-error: true` for months — operators read it as green when it was effectively unmonitored. Replaced with a smaller `migrate-dryrun` job that retains the static `manage.py migrate --verify-reversible` walk, builds the image, then runs `manage.py migrate --dry-run` inside it against an empty DB. `publish` and `publish-main` gate on its clean exit. Same "migrations look right" guarantee the simulation tried to provide, without the SELinux/bind-mount maintenance burden. The in-process data-survival side of the Phase 21.5 contract still ships via `tests/test_upgrade.py`.
 
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -93,7 +93,7 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 28.3 — Fix or retire `upgrade-simulation` (#31)
 
-- [ ] The CI job is `continue-on-error: true` with a "Tracked: TODO" note stranded for months. Either root-cause the SELinux-on-bind-mount failure and flip blocking, or retire the job entirely and replace it with a simpler `podman run --rm ghcr.io/.../resume-site:main migrate --dry-run` probe that runs in `publish`. v0.3.3 picks one.
+- [x] The CI job is `continue-on-error: true` with a "Tracked: TODO" note stranded for months. Either root-cause the SELinux-on-bind-mount failure and flip blocking, or retire the job entirely and replace it with a simpler `podman run --rm ghcr.io/.../resume-site:main migrate --dry-run` probe that runs in `publish`. v0.3.3 picks one. **Decision: retired.** New `migrate-dryrun` CI job (`needs: container-build`) builds the image fresh and runs `manage.py migrate --dry-run` inside it; `publish` and `publish-main` now gate on `migrate-dryrun` instead of `upgrade-simulation`. `docs/UPGRADE.md` updated to reference the new probe.
 
 ### 28.4 — Quadlet / systemd hardening (#27)
 

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -3,10 +3,11 @@
 How to move a running resume-site deployment from one published image
 tag to a newer one without losing data or downtime beyond a restart.
 This is the operator-facing counterpart to the Phase 21.5 upgrade
-survivability guarantees: the CI `upgrade-simulation` job verifies that
-the swap path below works on every push, and the
+survivability guarantees: the CI `migrate-dryrun` job (Phase 28.3)
+runs `manage.py migrate --dry-run` against the freshly built image
+before any tag is pushed, and the
 `manage.py migrate --verify-reversible` check rejects any migration
-that would put it at risk.
+that would put data at risk.
 
 ---
 
@@ -271,11 +272,18 @@ safety net, not a rollback trigger.
 
 ## 5. Known-safe upgrade paths
 
-The CI `upgrade-simulation` job verifies these paths on every push:
+CI verifies migration soundness on every push via the `migrate-dryrun`
+job (Phase 28.3): it builds the candidate image and runs
+`manage.py migrate --dry-run` inside it against an empty DB, so a
+syntactically broken migration or a missing migrations/ file in the
+image fails the publish gate before any tag is pushed. The in-process
+`tests/test_upgrade.py` suite covers the data-survival side — it
+boots a `v0.3.0-beta` schema, seeds realistic content, and replays
+every shipped migration on top.
 
 | From | To | Path |
 |---|---|---|
-| `:latest` (prior release) | `:vX.Y.Z` (newly built) | covered every build |
+| empty DB | `:vX.Y.Z` (newly built) | dry-run probe, every build |
 | `v0.3.0-beta` | current `main` | covered by `tests/test_upgrade.py` |
 
 Anything older than `v0.3.0-beta` is not covered by automation. If


### PR DESCRIPTION
## Summary

- Retires the long-advisory `upgrade-simulation` CI job (issue #31). It was stranded as `continue-on-error: true` for months — bind-mount permissions kept tripping over SELinux on the GitHub runner, so the gate was effectively unmonitored even though it read as green to operators.
- Replaces it with a smaller `migrate-dryrun` job (`needs: container-build`) that retains the static `manage.py migrate --verify-reversible` walk, builds the image, then runs `manage.py migrate --dry-run` inside it against an empty DB. `publish` and `publish-main` gate on its clean exit.
- Updates `docs/UPGRADE.md` (intro paragraph + section 5) to reference the new probe instead of the retired job. In-process data-survival side of the Phase 21.5 contract still ships via `tests/test_upgrade.py`.
- `manage.py migrate --dry-run` already existed (lines 814-818, 2250-2252) — no code change to `manage.py`.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean.
- [x] Job graph asserted programmatically: `upgrade-simulation` removed from `jobs:`; `migrate-dryrun` present; `publish` and `publish-main` `needs:` arrays updated.
- [x] No stale `upgrade-simulation` references in `docs/UPGRADE.md`. The remaining mentions in `.github/workflows/ci.yml` are in comments explicitly explaining the retirement.
- [x] Roadmap checkbox at `ROADMAP_v0.3.3.md:96` ticked with the retirement decision recorded.
- [ ] Local `python manage.py migrate --dry-run` smoke test skipped — werkzeug isn't installed in the worktree venv. The flag's code path (lines 814-818) is unchanged; CI will exercise it on the publish gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)