### PR TITLE
Phase 37.2: @deprecated decorator + webhook envelope + metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `create_review` + `mark_token_used` now run inside an explicit `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` transaction with a third in-transaction token re-validate. Before, two separate statements without a transaction meant two concurrent submissions of the same token could both succeed (race between "token valid" check and "mark used" update). Now exactly one wins; the losing caller rolls back cleanly. `app.db._InstrumentedConnection` doesn't forward the context-manager protocol so the explicit form is used instead of `with db:`.
 - Regression test `test_review_token_concurrent_submission_rejected` in `tests/test_integration.py` asserts exactly one review row exists after two simultaneous POSTs of the same token.
 
+### Added — Phase 37.2: `@deprecated` decorator + webhook envelope deprecation keys + metric
+
+- New `app/services/deprecation.py` with `@deprecated(sunset_date, replacement=None, reason=None)` decorator. Stamps responses with `Deprecation: true` (RFC 9745 draft), `Sunset: <HTTP-date>` (RFC 8594 — ISO date converted via `email.utils.format_datetime` so the day/month names are locale-safe), and `Link: <url>; rel="successor-version"` when a replacement is named. Logs an INFO record on `app.api.deprecation` per call with request id, endpoint name, `User-Agent`, and optional `X-Client-ID` so operators can identify lingering consumers. Idempotent across decorator stacking — the inner wrapper stamps headers + counter + log, the outer wrapper sees `Deprecation` already set and bows out.
+- New Prometheus counter `resume_site_deprecated_api_calls_total{endpoint}` increments once per call. Operators graph against the configured sunset date to confirm consumers have migrated; a still-non-zero rate close to the date pushes the sunset.
+- Webhook envelope plumbing in `app.services.webhooks._build_envelope`: optional `deprecated=True` and `sunset='<iso>'` kwargs inject `"deprecated": true` / `"sunset": <iso>` keys into the inner `data` payload. Default-off; existing callers untouched. Mirrors the HTTP header pair so a webhook consumer can subscribe to the same warning lifecycle when an event schema is on its way out.
+- Imported (`# noqa: F401`) into `app/routes/api.py` so the symbol is on the route-module's import surface; no existing route is decorated yet — the first usage waits for v0.4.0.
+- Six tests in `tests/test_deprecation.py` cover the three headers, the `Link: rel="successor-version"` form, the INFO log line on `app.api.deprecation` (via `caplog`), the counter increment, decorator-stacking idempotency, and the webhook envelope plumbing.
+
 ### Added — Phase 37.1: API compatibility policy doc
 
 - New `docs/API_COMPATIBILITY.md` — the stated contract between this codebase and any API / webhook consumer. Enumerates what MAY NOT change within a major version prefix (endpoints, field names, field types, error codes, event names, webhook envelope shape), what MAY change non-breakingly (new fields, new codes, new events, stricter validation), and the deprecation process every breaking change must go through (at minimum one release of `Deprecation`/`Sunset`/`Link` headers + CHANGELOG `Deprecated` entry + explicit removal release). Paired with the existing `docs/UPGRADE.md` which guarantees data survival; this doc closes the orthogonal consumer-contract gap.
@@ -99,6 +107,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Permanent `### Deprecated` subsection template under every `[Unreleased]` heading in `CHANGELOG.md`. When an operator deprecates an endpoint, the one-line note lands here — the empty section is the slot, and the CI guard below ensures it gets filled.
 - New `quality`-job step in `.github/workflows/ci.yml` (after the SQL-interpolation grep, before the `debug=True` guard) that fails the build when a PR adds `@deprecated(` to anything under `app/` without a matching addition under a `### Deprecated` heading in `CHANGELOG.md`. Push events to main are a no-op (no diff base). The error message points to `docs/API_COMPATIBILITY.md` for the deprecation contract.
+- Deferred to v0.3.3 or v0.4.0: OpenAPI spec drift guard (37.3) and CHANGELOG-enforcement CI grep (37.4). 37.2 (`@deprecated` decorator + metric + envelope plumbing) lands in this release.
 
 ### Security — Phase 25.3: bounded webhook-dispatch thread pool (#47)
 

--- a/ROADMAP_v0.3.2.md
+++ b/ROADMAP_v0.3.2.md
@@ -186,14 +186,14 @@ The new piece — **Phase 37, a formal API compatibility / deprecation policy** 
 
 ### 37.2 — `Sunset` / `Deprecation` HTTP headers
 
-- [ ] `app/routes/api.py` gains a `@deprecated(sunset_date, replacement=None, reason=None)` decorator that:
+- [x] `app/routes/api.py` gains a `@deprecated(sunset_date, replacement=None, reason=None)` decorator that:
   - Sets `Deprecation: true` header (RFC 9745 draft — widely enough implemented to be useful).
   - Sets `Sunset: <HTTP-date>` header (RFC 8594) from the passed `sunset_date`.
   - Sets `Link: <replacement_url>; rel="successor-version"` when a replacement is named.
   - Logs the deprecated call at INFO on `app.api.deprecation` with the request id + endpoint + source (user-agent + optional `X-Client-ID`) so operators can see who's still calling.
   - No-ops on responses that have already set these headers (idempotent across decorator stacking).
-- [ ] Matching webhook-envelope deprecation: a `deprecated: true` optional key on the webhook `data` payload when the event schema is flagged for removal; a `sunset` ISO-8601 key carries the same date as the HTTP header. Webhook consumers can subscribe to a warning log on first seeing the flag.
-- [ ] New metric `resume_site_deprecated_api_calls_total{endpoint}` — lets operators see if any consumer is still hitting a deprecated endpoint as the sunset date approaches.
+- [x] Matching webhook-envelope deprecation: a `deprecated: true` optional key on the webhook `data` payload when the event schema is flagged for removal; a `sunset` ISO-8601 key carries the same date as the HTTP header. Webhook consumers can subscribe to a warning log on first seeing the flag.
+- [x] New metric `resume_site_deprecated_api_calls_total{endpoint}` — lets operators see if any consumer is still hitting a deprecated endpoint as the sunset date approaches.
 
 ### 37.3 — OpenAPI spec support
 

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -93,6 +93,9 @@ from app.services.blog import (
     unpublish_post,
     update_post,
 )
+from app.services.deprecation import (  # Phase 37.2 — plumbing imported; no route flagged yet
+    deprecated,  # noqa: F401
+)
 from app.services.form import get_stripped
 from app.services.pagination import clamp_page, offset_for, paginate
 from app.services.reviews import (

--- a/app/services/deprecation.py
+++ b/app/services/deprecation.py
@@ -1,0 +1,130 @@
+"""
+API Deprecation Decorator — Phase 37.2
+
+Provides the ``@deprecated`` decorator for marking REST API endpoints
+that are scheduled for removal. The decorator stamps the response with
+the standard deprecation headers (RFC 9745 ``Deprecation`` + RFC 8594
+``Sunset`` + RFC 8288 ``Link: rel="successor-version"``), logs a
+structured INFO line so operators can see who is still calling the
+route, and increments a per-endpoint Prometheus counter.
+
+The machinery lands in this module ahead of the first real usage so
+the API contract change can be reviewed in isolation. No existing
+route is decorated by this PR — the first ``@deprecated`` call site
+will accompany the v0.4.0 ``/api/v2/`` rollout.
+
+Stdlib only — ``functools.wraps`` for the decorator, ``email.utils``
+for the locale-safe HTTP-date format. The metric counter is borrowed
+from :mod:`app.services.metrics` so deprecated-call accounting shares
+the existing exposition machinery.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from datetime import UTC, datetime
+from email.utils import format_datetime
+
+from flask import g, has_request_context, make_response, request
+
+from app.services.metrics import deprecated_api_calls_total
+
+_log = logging.getLogger('app.api.deprecation')
+
+
+def _to_http_date(sunset_date: str) -> str:
+    """Convert an ISO ``YYYY-MM-DD`` date to an RFC 7231 HTTP-date.
+
+    Uses ``email.utils.format_datetime`` rather than ``strftime('%a, %d
+    %b %Y ...')`` so the day / month names are emitted in the C locale
+    regardless of the host's ``LC_TIME`` setting — the HTTP spec
+    requires English abbreviations.
+    """
+    parsed = datetime.strptime(sunset_date, '%Y-%m-%d').replace(tzinfo=UTC)
+    return format_datetime(parsed, usegmt=True)
+
+
+def deprecated(
+    sunset_date: str,
+    *,
+    replacement: str | None = None,
+    reason: str | None = None,
+):
+    """Mark a Flask view as deprecated.
+
+    Args:
+        sunset_date: ISO-8601 ``YYYY-MM-DD`` date when the endpoint will
+            stop being served. Translated into an RFC 7231 HTTP-date for
+            the ``Sunset`` response header.
+        replacement: Optional URL of the successor endpoint. When set,
+            adds a ``Link: <url>; rel="successor-version"`` header.
+        reason: Optional human-readable explanation. Recorded in the
+            log line so operators can see *why* an endpoint went away.
+
+    Effects on every call:
+
+    * Sets ``Deprecation: true`` (RFC 9745 draft).
+    * Sets ``Sunset: <HTTP-date>`` derived from ``sunset_date``.
+    * Sets ``Link: <replacement>; rel="successor-version"`` when
+      ``replacement`` is supplied.
+    * Logs an INFO record on ``app.api.deprecation`` with the request
+      id (when in a request context), endpoint name, ``User-Agent``,
+      and optional ``X-Client-ID`` header value so operators can see
+      who's still calling.
+    * Increments
+      ``resume_site_deprecated_api_calls_total{endpoint=<name>}``.
+
+    Idempotent across decorator stacking: in a stack of two
+    ``@deprecated`` calls, the inner wrapper runs first and stamps the
+    headers, log line, and counter; the outer wrapper sees
+    ``Deprecation`` already set on the response and skips its own
+    writes. This keeps a route's surface clean (no double-count, no
+    duplicate log line, no header overwrite) even when middleware
+    composition accidentally produces a stack.
+    """
+    sunset_http_date = _to_http_date(sunset_date)
+
+    def _decorator(view):
+        endpoint_name = getattr(view, '__name__', '<view>')
+
+        @functools.wraps(view)
+        def _wrapped(*args, **kwargs):
+            response = make_response(view(*args, **kwargs))
+            # Idempotency: in a stack of two @deprecated calls the inner
+            # wrapper runs first (it's closer to the view), and by the
+            # time we get here on the outer wrapper, Deprecation is
+            # already set. Bow out so we don't double-count, double-log,
+            # or overwrite the inner decorator's chosen sunset / link.
+            if response.headers.get('Deprecation'):
+                return response
+
+            response.headers['Deprecation'] = 'true'
+            response.headers['Sunset'] = sunset_http_date
+            if replacement:
+                response.headers['Link'] = f'<{replacement}>; rel="successor-version"'
+
+            if has_request_context():
+                request_id = getattr(g, 'request_id', None) or '-'
+                user_agent = request.headers.get('User-Agent', '-')
+                client_id = request.headers.get('X-Client-ID', '-')
+            else:
+                request_id = user_agent = client_id = '-'
+
+            _log.info(
+                'deprecated API call: endpoint=%s sunset=%s reason=%s '
+                'request_id=%s user_agent=%s client_id=%s',
+                endpoint_name,
+                sunset_date,
+                reason or '-',
+                request_id,
+                user_agent,
+                client_id,
+            )
+
+            deprecated_api_calls_total.inc(label_values=(endpoint_name,))
+            return response
+
+        return _wrapped
+
+    return _decorator

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -404,6 +404,19 @@ login_attempts_total = _registry.counter(
     label_names=('outcome',),
 )
 
+# Phase 37.2 — deprecated-API call counter.
+#
+# Increments once per call to any route wearing the
+# ``@app.services.deprecation.deprecated`` decorator, labelled by
+# Flask endpoint name. Operators graph this against the configured
+# sunset date to confirm consumers have migrated; if the rate is still
+# non-zero close to the date, the sunset gets pushed.
+deprecated_api_calls_total = _registry.counter(
+    'resume_site_deprecated_api_calls_total',
+    'Calls to API endpoints flagged with the @deprecated decorator, by endpoint name.',
+    label_names=('endpoint',),
+)
+
 
 # ---------------------------------------------------------------------------
 # Request instrumentation helper

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -585,13 +585,28 @@ def sign_payload(secret: str | bytes, body: str | bytes) -> str:
     return hmac.new(secret, body, sha256).hexdigest()
 
 
-def _build_envelope(event_name, payload):
+def _build_envelope(event_name, payload, *, deprecated=None, sunset=None):
     """Canonical wire envelope. Stable so downstream verifiers can rely on it.
 
     JSON serialisation uses ``sort_keys=True`` so the same payload
     always hashes to the same signature regardless of dict iteration
     order.
+
+    Phase 37.2 deprecation plumbing: when ``deprecated`` is truthy,
+    inject ``"deprecated": true`` and (when present) ``"sunset": <iso>``
+    keys into ``payload`` so a webhook consumer can detect that the
+    event schema is on its way out — mirrors the HTTP
+    ``Deprecation`` / ``Sunset`` header pair. The keys live on the
+    inner ``data`` payload rather than the envelope so consumers
+    that already crawl ``data`` for typed fields see the flag without
+    extra parsing. No event is flagged in this PR; the callers stay
+    on the no-arg form until the first real deprecation.
     """
+    if deprecated:
+        payload = dict(payload)  # don't mutate the caller's dict
+        payload['deprecated'] = True
+        if sunset:
+            payload['sunset'] = sunset
     envelope = {
         'event': event_name,
         'timestamp': _now_iso(),

--- a/tests/test_alerting_rules.py
+++ b/tests/test_alerting_rules.py
@@ -240,6 +240,11 @@ def test_every_custom_metric_is_referenced_at_least_once(all_rules, custom_metri
         'resume_site_photo_uploads_total',
         'resume_site_contact_submissions_total',
         'resume_site_blog_posts_total',
+        # Phase 37.2: deprecated-API call counter exists so operators can
+        # see consumer migration progress as a sunset date approaches.
+        # Not alertable on its own — a non-zero value is informational
+        # (operators set their own threshold per deprecation timeline).
+        'resume_site_deprecated_api_calls_total',
     }
 
     all_expr_text = '\n'.join(r['expr'] for r in all_rules)

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,236 @@
+"""
+Deprecation Decorator Tests — Phase 37.2
+
+Covers ``app.services.deprecation.deprecated`` plus the matching
+webhook envelope plumbing in ``app.services.webhooks._build_envelope``.
+
+Each test wires the decorator onto a throwaway view registered via a
+small Blueprint on the existing ``app`` fixture, then drives it with
+the standard test client. The metric counter is read straight off
+``deprecated_api_calls_total.samples()`` to confirm the per-endpoint
+label increments, and the INFO log line is captured via pytest's
+``caplog`` fixture.
+
+No real network traffic; the webhook envelope test exercises the
+internal ``_build_envelope`` helper directly so we don't have to spin
+up a fake HTTP server.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from flask import Blueprint, jsonify
+
+from app.services.deprecation import _to_http_date, deprecated
+from app.services.metrics import deprecated_api_calls_total
+from app.services.webhooks import _build_envelope
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _counter_value(endpoint_name):
+    """Return the current counter value for one endpoint label, or 0 if absent."""
+    for _name, labels, value in deprecated_api_calls_total.samples():
+        if labels.get('endpoint') == endpoint_name:
+            return value
+    return 0
+
+
+@pytest.fixture
+def deprecated_route_app(app):
+    """Register a tiny throwaway Blueprint with a deprecated route.
+
+    Yields ``(app, endpoint_name)`` so the test can drive a request and
+    later look up the counter value by the same endpoint name.
+    """
+    bp = Blueprint('test_deprecation', __name__)
+
+    @bp.route('/__test_deprecated')
+    @deprecated(sunset_date='2030-01-01')
+    def deprecated_view():
+        return jsonify(ok=True)
+
+    app.register_blueprint(bp)
+    yield app, 'deprecated_view'
+
+
+# ---------------------------------------------------------------------------
+# HTTP-date helper
+# ---------------------------------------------------------------------------
+
+
+def test_to_http_date_emits_rfc7231_format():
+    # email.utils.format_datetime with usegmt=True ends in ' GMT' and
+    # uses C-locale day/month names.
+    got = _to_http_date('2030-01-01')
+    assert got.endswith(' GMT')
+    assert 'Tue, 01 Jan 2030' in got
+
+
+# ---------------------------------------------------------------------------
+# Decorator: headers
+# ---------------------------------------------------------------------------
+
+
+def test_deprecated_sets_three_headers(deprecated_route_app):
+    app, _endpoint = deprecated_route_app
+    client = app.test_client()
+    resp = client.get('/__test_deprecated')
+    assert resp.status_code == 200
+    assert resp.headers.get('Deprecation') == 'true'
+    sunset = resp.headers.get('Sunset')
+    assert sunset is not None
+    # Phase 37.2 — Sunset must be an RFC 7231 HTTP-date, not the raw
+    # ISO date string.
+    assert sunset.endswith(' GMT')
+    assert 'Jan 2030' in sunset
+
+
+def test_deprecated_with_replacement_sets_link_header(app):
+    bp = Blueprint('test_deprecation_link', __name__)
+
+    @bp.route('/__test_deprecated_link')
+    @deprecated(sunset_date='2030-01-01', replacement='/api/v2/posts')
+    def view():
+        return jsonify(ok=True)
+
+    app.register_blueprint(bp)
+    client = app.test_client()
+    resp = client.get('/__test_deprecated_link')
+    assert resp.status_code == 200
+    link = resp.headers.get('Link')
+    assert link is not None
+    assert '/api/v2/posts' in link
+    assert 'rel="successor-version"' in link
+
+
+def test_deprecated_without_replacement_omits_link_header(deprecated_route_app):
+    app, _endpoint = deprecated_route_app
+    client = app.test_client()
+    resp = client.get('/__test_deprecated')
+    assert resp.headers.get('Link') is None
+
+
+# ---------------------------------------------------------------------------
+# Decorator: logging
+# ---------------------------------------------------------------------------
+
+
+def test_deprecated_logs_info_on_app_api_deprecation(deprecated_route_app, caplog):
+    app, _endpoint = deprecated_route_app
+    client = app.test_client()
+    with caplog.at_level(logging.INFO, logger='app.api.deprecation'):
+        resp = client.get(
+            '/__test_deprecated',
+            headers={'User-Agent': 'pytest-deprecation/1.0', 'X-Client-ID': 'consumer-42'},
+        )
+    assert resp.status_code == 200
+
+    matching = [r for r in caplog.records if r.name == 'app.api.deprecation']
+    assert matching, 'expected at least one INFO log on app.api.deprecation'
+    assert any(r.levelno == logging.INFO for r in matching)
+    # The user-agent and X-Client-ID make it into the message so
+    # operators can identify the caller.
+    rendered = ' '.join(r.getMessage() for r in matching)
+    assert 'pytest-deprecation/1.0' in rendered
+    assert 'consumer-42' in rendered
+
+
+# ---------------------------------------------------------------------------
+# Decorator: counter
+# ---------------------------------------------------------------------------
+
+
+def test_deprecated_increments_counter_per_call(deprecated_route_app):
+    app, endpoint = deprecated_route_app
+    client = app.test_client()
+    before = _counter_value(endpoint)
+    client.get('/__test_deprecated')
+    after_one = _counter_value(endpoint)
+    client.get('/__test_deprecated')
+    after_two = _counter_value(endpoint)
+    assert after_one == before + 1
+    assert after_two == before + 2
+
+
+# ---------------------------------------------------------------------------
+# Decorator: idempotent stacking
+# ---------------------------------------------------------------------------
+
+
+def test_stacked_deprecated_decorators_do_not_double_set_header(app, caplog):
+    """When @deprecated wraps a route already wearing @deprecated, the
+    outer decorator must no-op: the inner wrapper runs first and stamps
+    the headers + counter + log, the outer wrapper sees Deprecation
+    already set and bows out so we don't double-count or overwrite."""
+    bp = Blueprint('test_deprecation_stack', __name__)
+
+    @bp.route('/__test_deprecated_stack')
+    @deprecated(sunset_date='2030-01-01', replacement='/api/v2/outer')
+    @deprecated(sunset_date='2031-06-15', replacement='/api/v2/inner')
+    def view():
+        return jsonify(ok=True)
+
+    app.register_blueprint(bp)
+    client = app.test_client()
+    before = _counter_value('view')
+
+    with caplog.at_level(logging.INFO, logger='app.api.deprecation'):
+        resp = client.get('/__test_deprecated_stack')
+
+    assert resp.status_code == 200
+    # Inner wrapper executes first and writes the headers; the outer
+    # wrapper finds ``Deprecation`` already set and skips its own
+    # writes — so the visible values are the inner decorator's.
+    assert resp.headers.get('Deprecation') == 'true'
+    assert '/api/v2/inner' in resp.headers.get('Link', '')
+    # Sunset matches the inner (2031), not the outer (2030).
+    assert 'Jun 2031' in resp.headers.get('Sunset', '')
+
+    # Exactly one INFO log line, exactly one counter bump — proof the
+    # outer wrapper truly no-op'd.
+    matching = [r for r in caplog.records if r.name == 'app.api.deprecation']
+    assert len(matching) == 1
+    after = _counter_value('view')
+    assert after == before + 1
+
+
+# ---------------------------------------------------------------------------
+# Webhook envelope plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_envelope_injects_deprecated_and_sunset_keys():
+    body = _build_envelope(
+        'blog.published',
+        {'post_id': 42},
+        deprecated=True,
+        sunset='2030-01-01',
+    )
+    envelope = json.loads(body)
+    assert envelope['event'] == 'blog.published'
+    assert envelope['data']['post_id'] == 42
+    assert envelope['data']['deprecated'] is True
+    assert envelope['data']['sunset'] == '2030-01-01'
+
+
+def test_webhook_envelope_omits_keys_when_not_deprecated():
+    body = _build_envelope('blog.published', {'post_id': 42})
+    envelope = json.loads(body)
+    assert 'deprecated' not in envelope['data']
+    assert 'sunset' not in envelope['data']
+
+
+def test_webhook_envelope_does_not_mutate_caller_payload():
+    """The caller's payload dict must not gain ``deprecated`` / ``sunset``
+    keys as a side effect — webhook fan-out hands the same payload
+    object to multiple subscribers."""
+    payload = {'post_id': 42}
+    _build_envelope('blog.published', payload, deprecated=True, sunset='2030-01-01')
+    assert 'deprecated' not in payload
+    assert 'sunset' not in payload


### PR DESCRIPTION
## Summary

- New `app/services/deprecation.py` ships the `@deprecated(sunset_date, replacement=None, reason=None)` decorator. Stamps `Deprecation: true` (RFC 9745 draft), `Sunset: <HTTP-date>` (RFC 8594, locale-safe via `email.utils.format_datetime`), and `Link: <url>; rel="successor-version"` when a replacement is named. Logs an INFO record on `app.api.deprecation` per call with request id, endpoint name, `User-Agent`, and optional `X-Client-ID`. Idempotent across decorator stacking — inner wrapper stamps, outer wrapper bows out when `Deprecation` is already set so we don't double-count, double-log, or overwrite.
- New Prometheus counter `resume_site_deprecated_api_calls_total{endpoint}` declared in `app/services/metrics.py`. Increments once per call so operators can graph remaining consumers as the sunset date approaches.
- Webhook envelope plumbing: `_build_envelope` in `app/services/webhooks.py` gains optional `deprecated=` and `sunset=` kwargs. When `deprecated` is truthy, injects `"deprecated": true` and (when present) `"sunset": <iso>` keys into the inner `data` payload via a shallow-copied dict (no mutation of the caller's payload). Default-off; existing callers untouched. No event flagged in this PR.
- Decorator imported into `app/routes/api.py` (`# noqa: F401`) — machinery is on the route module's import surface, no existing route decorated yet. First usage waits for v0.4.0 / `/api/v2/`.

## Test plan

- [x] `python -m pytest tests/test_deprecation.py -x -v` — 10 new tests pass (HTTP-date format, three headers, `Link: rel="successor-version"`, no-replacement omits Link, INFO log via `caplog`, counter increment, decorator-stacking idempotency, envelope keys injected, envelope keys absent without flag, envelope doesn't mutate caller payload).
- [x] `python -m pytest tests/test_webhooks.py tests/test_metrics.py tests/test_api.py` — 230 existing tests still green; nothing regressed in webhook envelope, metrics registry, or REST API surface.
- [x] `ruff check` + `ruff format --check` clean across all five touched files.
- [x] CHANGELOG `[Unreleased] v0.3.2 (Shield)` gains a "Added — Phase 37.2" entry; "Deprecated" section deliberately not added (no endpoints flagged yet — machinery only).
- [x] ROADMAP_v0.3.2.md lines 189-196 ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)