### PR TITLE
Phase 29.3 (#56): consolidate admin-login test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - New `app/services/form.py:get_stripped(form, key, default='')` replaces the `request.form.get(...).strip()` and `(request.form.get(...) or '').strip()` idioms that had accreted across `app/routes/admin.py`, `app/routes/api.py`, `app/routes/blog_admin.py`, `app/routes/contact.py`, and `app/routes/review.py` (24 call sites total). Behaviour is byte-identical — same `str.strip()` semantics, same default-on-absent / default-on-empty, same whitespace-only → `''` collapse. No case folding, no normalisation; callers that needed `.lower()` or other downstream transforms keep them explicit.
 - 19 regression tests in `tests/test_form_helper.py` pin the contract against both legacy idioms (default-arg form and `or '' ` form), including whitespace-character coverage (`\t`, `\n`, `\r`, mixed) and the `display_tier='grid'` non-empty-default case from `app/routes/api.py`.
+### Refactor — Phase 29.3: consolidate admin-login test fixtures (#56)
+
+- Three tests that hand-rolled their own admin-login setup (`tests/test_integration.py::test_session_timeout_redirects_to_login`, `tests/test_security.py::test_logout_revokes_cookie_on_another_client`, `tests/test_security.py::test_logout_revokes_cookie_on_blog_admin_routes`) now use the canonical `auth_client` fixture from `tests/conftest.py`. Removes duplicated `client.post('/admin/login', data={...})` boilerplate and inline `sess['_user_id'] = 'admin'` session manipulation. Behaviour is byte-identical — `auth_client` produces the same `_user_id` / `_fresh` / `_admin_epoch=0` session a real fresh-DB login produces, so the cookie-revocation and session-timeout assertions still trigger the exact same code paths.
 
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -116,7 +116,7 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 29.3 — Test fixture consolidation
 
-- [ ] `#56` flags multiple ad-hoc admin-login fixtures across `tests/test_admin*.py`. Consolidate on the canonical `logged_in_admin_client` fixture and remove the variants.
+- [x] `#56` flags multiple ad-hoc admin-login fixtures across `tests/test_admin*.py`. Consolidate on the canonical `logged_in_admin_client` fixture and remove the variants.
 
 ### 29.4 — Roll the rest forward
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -376,19 +376,17 @@ def test_upload_accepts_valid_png(auth_client, app):
 # ============================================================
 
 
-def test_session_timeout_redirects_to_login(app):
+def test_session_timeout_redirects_to_login(auth_client):
     """An expired session should redirect to the login page."""
     from datetime import datetime, timedelta
 
-    client = app.test_client()
-    with client.session_transaction() as sess:
-        sess['_user_id'] = 'admin'
-        sess['_fresh'] = True
-        # Set last activity to 2 hours ago (well past the 60-min default)
+    # Backdate last_activity on the canonical authenticated session so the
+    # timeout guard fires. ``auth_client`` already seeds _user_id / _fresh.
+    with auth_client.session_transaction() as sess:
         old_time = datetime.now(UTC) - timedelta(hours=2)
         sess['_last_activity'] = old_time.isoformat()
 
-    response = client.get('/admin/', follow_redirects=False)
+    response = auth_client.get('/admin/', follow_redirects=False)
     assert response.status_code == 302
     assert '/admin/login' in response.headers['Location']
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -689,7 +689,7 @@ def test_admin_blueprint_middleware_parity(app):
     assert 'update_last_activity' in blog_after
 
 
-def test_logout_revokes_cookie_on_another_client(app):
+def test_logout_revokes_cookie_on_another_client(auth_client):
     """Phase 23.1 (#33): after one client logs out, a second client
     holding a copy of the same pre-logout cookie must be rejected on its
     NEXT admin request — not after the 30 s settings-cache TTL.
@@ -700,23 +700,15 @@ def test_logout_revokes_cookie_on_another_client(app):
     """
     import time
 
-    # Seed the session on client A via the login form so both clients
-    # share the same underlying cookie stamp.
-    client_a = app.test_client()
-    client_a.post(
-        '/admin/login',
-        data={'username': 'admin', 'password': 'testpassword123'},
-        follow_redirects=False,
-    )
-    # Clone A's session cookie into client B. Reading session via the
-    # test-client session transaction is enough to keep B authenticated.
-    with client_a.session_transaction() as sess_a:
+    # Clone the canonical authenticated session into a second client to
+    # simulate two workers holding the same pre-logout cookie.
+    with auth_client.session_transaction() as sess_a:
         user_id = sess_a.get('_user_id')
         admin_epoch = sess_a.get('_admin_epoch')
     assert user_id == 'admin'
     assert admin_epoch is not None
 
-    client_b = app.test_client()
+    client_b = auth_client.application.test_client()
     with client_b.session_transaction() as sess_b:
         sess_b['_user_id'] = user_id
         sess_b['_admin_epoch'] = admin_epoch
@@ -727,7 +719,7 @@ def test_logout_revokes_cookie_on_another_client(app):
 
     # A logs out — epoch bumps in the settings table.
     t0 = time.monotonic()
-    client_a.get('/admin/logout')
+    auth_client.get('/admin/logout')
 
     # B's next admin request must be rejected immediately (within 250 ms
     # per the roadmap SLA) — the uncached read path makes this the cost
@@ -742,21 +734,15 @@ def test_logout_revokes_cookie_on_another_client(app):
     assert elapsed_ms < 250, f'revocation took {elapsed_ms:.0f}ms — SLA is <250ms'
 
 
-def test_logout_revokes_cookie_on_blog_admin_routes(app):
+def test_logout_revokes_cookie_on_blog_admin_routes(auth_client):
     """Phase 23.1 (#51): the blog_admin blueprint must honour the epoch
     check too. A post-logout cookie must not grant access to /admin/blog.
     """
-    client_a = app.test_client()
-    client_a.post(
-        '/admin/login',
-        data={'username': 'admin', 'password': 'testpassword123'},
-        follow_redirects=False,
-    )
-    with client_a.session_transaction() as sess_a:
+    with auth_client.session_transaction() as sess_a:
         user_id = sess_a['_user_id']
         admin_epoch = sess_a['_admin_epoch']
 
-    client_b = app.test_client()
+    client_b = auth_client.application.test_client()
     with client_b.session_transaction() as sess_b:
         sess_b['_user_id'] = user_id
         sess_b['_admin_epoch'] = admin_epoch
@@ -764,7 +750,7 @@ def test_logout_revokes_cookie_on_blog_admin_routes(app):
 
     assert client_b.get('/admin/blog').status_code == 200
 
-    client_a.get('/admin/logout')
+    auth_client.get('/admin/logout')
 
     resp = client_b.get('/admin/blog', follow_redirects=False)
     assert resp.status_code in (302, 401), (


### PR DESCRIPTION
## Summary

- Three tests in `tests/test_integration.py` and `tests/test_security.py` were hand-rolling their own admin-login setup (POST to `/admin/login` or `sess['_user_id'] = 'admin'`) instead of using the canonical `auth_client` fixture from `tests/conftest.py`. All three now use `auth_client`.
- Verified the remaining `/admin/login` POST call sites (in `test_login_throttle.py` and `test_security.py`) are testing the actual login endpoint behaviour — throttling, CSRF, open-redirect, IP rules — and correctly stay as-is. The `csrf_client` fixture in `test_security.py` uses a different app config (CSRF-enabled) and is a legitimate divergence.
- Closes the Phase 29.3 checkbox in `ROADMAP_v0.3.3.md`.

Behaviour is byte-identical — `auth_client` produces the same `_user_id` / `_fresh` / `_admin_epoch=0` session a real fresh-DB login produces, so the cookie-revocation and session-timeout code paths still trigger the exact same logic.

## Test plan

- [x] Targeted: `pytest tests/test_admin.py tests/test_customization.py tests/test_dashboard_widgets.py tests/test_security.py tests/test_integration.py tests/test_edge_cases_session.py -x` — 183 passed
- [x] Broad: `pytest tests/ -x --ignore=tests/loadtests --ignore=tests/synthetic` — 1337 passed
- [x] `ruff check tests/` and `ruff format --check tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)