### PR TITLE
Phase 26.5 (#36): cache photo-directory size for /metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `process_upload` now calls `img.draft('RGB', (2000, 2000))` immediately after `Image.open()` when the source is a JPEG. Pillow forwards this to libjpeg-turbo which emits a smaller image during DCT decoding — so the LANCZOS resize that follows works on a buffer already close to the 2000 px target rather than the full 6000 px source. Measured ~2.74× faster on a synthetic 24 MP gradient JPEG (median of 5 in-process iterations); libjpeg-turbo docs cite 4-8× on real DSLR JPEGs with 3-5 MB on-disk size and high-frequency detail. The "Photo upload CPU" perf cliff for 24 MP DSLR JPEGs drops from ≈ 5 s to ~1-2 s. Variant ladder (640w / 1024w / 2000 px) is unchanged; EXIF stripping still works.
 - Three regression tests in `tests/test_photo_processing.py`: full variant ladder produced for a 24 MP fixture, post-`draft()` output stays within 1% byte tolerance of the pre-change pipeline at the same `quality=85` save (compared via monkeypatched draft no-op), and EXIF tags are still stripped on the 24 MP path.
+### Performance — Phase 26.5: cache photo-directory size for `/metrics` (#36)
+
+- The `resume_site_disk_usage_bytes{path="photos"}` gauge previously walked the entire photo directory on every Prometheus scrape — at 10 k photos that was multiple seconds per scrape, paid by every reader. The route now reads a cached `photos_disk_usage_bytes` setting in O(1). Photo upload and delete bump the value by the file-size delta (primary file plus whatever responsive variants landed); `manage.py purge-all` reconciles to a ground-truth directory walk so steady-state drift is bounded by the purge cadence (typically 24 h). Fresh installs with a missing or zero cache fall back to a one-time walk and cache the result for the next scrape.
+- DB-size half left as-is — `os.stat()` on the SQLite file is already O(1) and always-fresh.
+- Two new internal-only settings: `photos_disk_usage_bytes`, `photos_disk_usage_updated_at`. Not surfaced in the admin UI (category `Internal` is excluded from `SETTINGS_CATEGORIES`).
+- Three regression tests in `tests/test_metrics.py`: gauge tracks an upload and delete in lockstep, scrapes never call the directory-walk function once the cache is populated, and a fresh install with no cache walks once and writes the result back.
+- `PERFORMANCE.md` documents the cached-scrape contract and the staleness window.
 
 ### Performance — Phase 26.3: paginate `/admin/blog` (#54)
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -595,6 +595,26 @@ before Postgres becomes necessary.
    `--max-requests 1000 --max-requests-jitter 100` for periodic
    recycling.
 
+### Cached scrape gauges (Phase 26.5, #36)
+
+| Gauge                                   | Strategy                                                                                | Staleness window                                                                                                               |
+|-----------------------------------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `resume_site_disk_usage_bytes{path="photos"}`   | `photos_disk_usage_bytes` setting, bumped by upload / delete deltas; reconciled by `manage.py purge-all` | **Bounded by `purge-all` cadence** (typical: 24 h via the Phase 25.1 `resume-site-purge.timer`). Live writes stay accurate.     |
+| `resume_site_disk_usage_bytes{path="database"}` | `os.stat()` on the SQLite file at scrape time                                           | None — O(1) and always fresh.                                                                                                  |
+
+The photos gauge used to walk the entire photo directory on every
+Prometheus scrape (`os.walk` + `os.path.getsize` per file). At 10 k
+photos that was multiple seconds per scrape, paid by every reader.
+Phase 26.5 caches the running total in the settings table, bumped
+in lockstep with upload / delete by the file-size delta, and
+reconciled to ground truth by `manage.py purge-all` (Phase 25.1).
+The scrape now reads one row from the settings cache — O(1) regardless
+of photo count.
+
+The DB-size gauge stayed put: `os.stat()` on the SQLite file is already
+O(1) and always reflects the live file size, so caching would only add
+drift for no win.
+
 ### Top cyclomatic-complexity hotspots
 
 Advisory — not perf bottlenecks, but cold-path complexity worth watching:

--- a/ROADMAP_v0.3.3.md
+++ b/ROADMAP_v0.3.3.md
@@ -66,9 +66,9 @@ Expect this release to take multiple sprints. The success criteria are hard numb
 
 ### 26.5 — `/metrics` disk-usage scrape cost (#36)
 
-- [ ] Currently walks the entire photo directory on every Prometheus scrape. At 10k photos this is seconds per scrape.
-- [ ] Cache the photo-directory size in the settings table (`photos_disk_usage_bytes`, `photos_disk_usage_updated_at`). Refresh in two places: (a) every photo upload/delete bumps the value by the file size delta (cheap); (b) the `manage.py purge-all` run (v0.3.2 Phase 25.1) writes a ground-truth total as a reconciliation step. `/metrics` reads the cached value in O(1). Document the staleness window (max 24 h between reconciliations).
-- [ ] Same pattern for the DB size gauge (stat the file, cheap — leave as-is).
+- [x] Currently walks the entire photo directory on every Prometheus scrape. At 10k photos this is seconds per scrape.
+- [x] Cache the photo-directory size in the settings table (`photos_disk_usage_bytes`, `photos_disk_usage_updated_at`). Refresh in two places: (a) every photo upload/delete bumps the value by the file size delta (cheap); (b) the `manage.py purge-all` run (v0.3.2 Phase 25.1) writes a ground-truth total as a reconciliation step. `/metrics` reads the cached value in O(1). Document the staleness window (max 24 h between reconciliations).
+- [x] Same pattern for the DB size gauge (stat the file, cheap — leave as-is).
 
 ### 26.6 — Benchmark harness sets its own log level (#64)
 

--- a/app/routes/metrics.py
+++ b/app/routes/metrics.py
@@ -109,7 +109,7 @@ def metrics():
     # Refresh scrape-time gauges (Phase 18.2 deferred batch).
     _refresh_blog_posts_gauge(db)
     _refresh_backup_timestamp_gauge(settings)
-    _refresh_disk_usage_gauge(current_app.config)
+    _refresh_disk_usage_gauge(current_app.config, settings, db)
 
     body = registry.render()
     return body, 200, {'Content-Type': CONTENT_TYPE}
@@ -139,8 +139,21 @@ def _refresh_backup_timestamp_gauge(settings):
         backup_last_success_timestamp.set(dt.replace(tzinfo=UTC).timestamp())
 
 
-def _refresh_disk_usage_gauge(app_config):
-    """Set disk_usage_bytes gauge for the database and photo directories."""
+def _refresh_disk_usage_gauge(app_config, settings, db):
+    """Set disk_usage_bytes gauge for the database and photo directories.
+
+    The DB-size half stays as a one-shot ``os.stat`` of the SQLite file —
+    cheap O(1) regardless of DB size, and there's no equivalent of the
+    photo-tree walk to avoid (Phase 26.5, #36 roadmap note: "leave as-is").
+
+    The photos half reads the cached ``photos_disk_usage_bytes`` setting
+    instead of walking the photo directory. Upload / delete bumps and
+    the ``manage.py purge-all`` reconciliation step keep the value
+    fresh; on a never-reconciled fresh install where the cache is
+    missing or zero we fall back to a single walk and then write the
+    result back so the next scrape is O(1) again. Bounded staleness
+    window is documented in PERFORMANCE.md.
+    """
     import os
 
     with contextlib.suppress(Exception):
@@ -148,12 +161,24 @@ def _refresh_disk_usage_gauge(app_config):
         if db_path and os.path.isfile(db_path):
             disk_usage_bytes.set(os.path.getsize(db_path), label_values=('database',))
 
+    photo_dir = app_config.get('PHOTO_STORAGE', '')
+    cached_raw = settings.get('photos_disk_usage_bytes', '')
+    try:
+        cached = int(cached_raw) if cached_raw else 0
+    except (TypeError, ValueError):
+        cached = 0
+
+    if cached > 0:
+        disk_usage_bytes.set(cached, label_values=('photos',))
+        return
+
+    # Fresh install / never-reconciled: walk once, cache, then serve
+    # the cached value on every subsequent scrape.
     with contextlib.suppress(Exception):
-        photo_dir = app_config.get('PHOTO_STORAGE', '')
-        if photo_dir and os.path.isdir(photo_dir):
-            total = sum(
-                os.path.getsize(os.path.join(dirpath, f))
-                for dirpath, _dirnames, filenames in os.walk(photo_dir)
-                for f in filenames
-            )
-            disk_usage_bytes.set(total, label_values=('photos',))
+        from app.services.photos import _photo_storage_total_bytes
+        from app.services.settings_svc import set_one
+
+        total = _photo_storage_total_bytes(photo_dir)
+        disk_usage_bytes.set(total, label_values=('photos',))
+        if total > 0 and db is not None:
+            set_one(db, 'photos_disk_usage_bytes', total)

--- a/app/services/photos.py
+++ b/app/services/photos.py
@@ -52,6 +52,63 @@ _MAGIC_BYTES = {
 _DEFAULT_MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
+def _bump_disk_usage_cache(delta_bytes: int) -> None:
+    """Adjust the cached photo-directory total by ``delta_bytes``.
+
+    Phase 26.5 (#36) — keeps ``photos_disk_usage_bytes`` in step with
+    upload / delete activity so the /metrics gauge can be served in
+    O(1) instead of walking the photo tree on every Prometheus scrape.
+    A downward drift past zero is clamped to zero so a missed-bump bug
+    can't take the gauge negative; reconciliation in ``manage.py
+    purge-all`` bounds steady-state drift to that cadence.
+
+    Wrapped in ``contextlib.suppress`` because gauge accuracy must
+    never block the surrounding upload / delete — a slow or unhealthy
+    DB at bump time would otherwise turn a Prometheus nicety into a
+    user-facing 500.
+    """
+    import contextlib
+
+    if delta_bytes == 0:
+        return
+    with contextlib.suppress(Exception):
+        from app.db import get_db
+        from app.services.settings_svc import set_one
+
+        db = get_db()
+        row = db.execute(
+            'SELECT value FROM settings WHERE key = ?',
+            ('photos_disk_usage_bytes',),
+        ).fetchone()
+        try:
+            current = int(row['value']) if row else 0
+        except (TypeError, ValueError):
+            current = 0
+        new_total = max(0, current + delta_bytes)
+        # ``set_one`` runs the upsert, commits, and busts the TTL cache
+        # so /metrics sees the fresh total without waiting on the 30 s
+        # window.
+        set_one(db, 'photos_disk_usage_bytes', new_total)
+
+
+def _photo_storage_total_bytes(photo_dir: str) -> int:
+    """Walk ``photo_dir`` once and return the total bytes of all files.
+
+    Used by the `/metrics` first-init fall-back and the
+    ``manage.py purge-all`` reconciliation step. Centralised here so
+    the metrics route doesn't have to import ``os.walk`` plumbing and
+    so tests can stub a single function to verify it isn't called on
+    the request hot path.
+    """
+    if not photo_dir or not os.path.isdir(photo_dir):
+        return 0
+    return sum(
+        os.path.getsize(os.path.join(dirpath, f))
+        for dirpath, _dirnames, filenames in os.walk(photo_dir)
+        for f in filenames
+    )
+
+
 def _get_photo_dir():
     """Resolve the photo storage directory to an absolute path."""
     photo_dir = current_app.config['PHOTO_STORAGE']
@@ -242,6 +299,14 @@ def process_upload(file_storage: FileStorage) -> dict[str, Any] | str | None:
         if quarantine_path and os.path.exists(quarantine_path):
             os.unlink(quarantine_path)
 
+    # Phase 26.5 (#36): bump the cached photo-directory total by the
+    # full delta written to disk for this upload — primary file plus
+    # whatever variants `_generate_responsive_variants` actually
+    # produced. Stat'ing the handful of UUID-prefixed siblings is
+    # O(variants), unlike the O(directory) walk we used to do on
+    # every /metrics scrape.
+    _bump_disk_usage_cache(_stat_storage_files(photo_dir, storage_name))
+
     # Map file extensions to MIME types
     mime_map = {
         '.jpg': 'image/jpeg',
@@ -259,6 +324,40 @@ def process_upload(file_storage: FileStorage) -> dict[str, Any] | str | None:
         'height': height,
         'file_size': file_size,
     }
+
+
+def _variant_storage_names(storage_name: str) -> list[str]:
+    """Return the storage_name plus every responsive-variant filename.
+
+    Single source of truth for the upload / delete / stat call sites
+    that need to enumerate every on-disk file backing a single photo
+    row. Variants that haven't been generated (``_generate_responsive_variants``
+    skips upscales for narrow originals) won't exist on disk; callers
+    use ``os.path.exists`` / ``os.path.getsize`` to skip those.
+    """
+    base, ext = os.path.splitext(storage_name)
+    return [
+        storage_name,
+        f'{base}.webp',
+        *[f'{base}_{w}w{ext}' for w in _RESPONSIVE_WIDTHS],
+    ]
+
+
+def _stat_storage_files(photo_dir: str, storage_name: str) -> int:
+    """Sum the on-disk bytes for ``storage_name`` plus its responsive variants.
+
+    Used by the upload cache-bump path so the gauge moves in lockstep
+    with what landed on disk, without paying for an ``os.walk`` of
+    the whole photo tree.
+    """
+    total = 0
+    for name in _variant_storage_names(storage_name):
+        path = os.path.join(photo_dir, name)
+        try:
+            total += os.path.getsize(path)
+        except OSError:
+            continue
+    return total
 
 
 _RESPONSIVE_WIDTHS = (640, 1024)
@@ -422,15 +521,19 @@ def delete_photo_file(storage_name: str) -> None:
     Args:
         storage_name: The UUID-based filename to delete.
     """
-    photo_dir = _get_photo_dir()
-    base, ext = os.path.splitext(storage_name)
+    import contextlib
 
-    candidates = [
-        storage_name,
-        f'{base}.webp',
-        *[f'{base}_{w}w{ext}' for w in _RESPONSIVE_WIDTHS],
-    ]
-    for name in candidates:
+    photo_dir = _get_photo_dir()
+    # Phase 26.5 (#36): tally the bytes about to disappear *before*
+    # the unlinks so the disk-usage gauge can be debited by the same
+    # delta. Stat'ing siblings that don't exist is fine — getsize
+    # raises OSError and we skip silently.
+    deleted_bytes = 0
+    for name in _variant_storage_names(storage_name):
         path = os.path.join(photo_dir, name)
         if os.path.exists(path):
+            with contextlib.suppress(OSError):
+                deleted_bytes += os.path.getsize(path)
             os.remove(path)
+    if deleted_bytes:
+        _bump_disk_usage_cache(-deleted_bytes)

--- a/app/services/settings_svc.py
+++ b/app/services/settings_svc.py
@@ -558,6 +558,35 @@ SETTINGS_REGISTRY = {
             'deliberate internal-service dispatch.'
         ),
     },
+    # --- Internal: photo disk-usage cache (Phase 26.5, #36) ---
+    # Auto-maintained — not surfaced in the admin settings UI. Bumped on
+    # every photo upload / delete by the file-size delta and reconciled
+    # by `manage.py purge-all` to a ground-truth directory walk. Lets
+    # /metrics serve the photo-disk gauge in O(1) instead of walking the
+    # tree on every Prometheus scrape. Staleness window between
+    # reconciliations is bounded by the purge-all cadence (typically
+    # 24 h).
+    'photos_disk_usage_bytes': {
+        'type': 'int',
+        'default': '0',
+        'label': 'Photos Disk Usage (bytes, internal)',
+        'category': 'Internal',
+        'description': (
+            'Cached total bytes of the photo storage directory. '
+            'Auto-maintained by upload / delete + reconciled by '
+            "manage.py purge-all. Don't edit by hand."
+        ),
+    },
+    'photos_disk_usage_updated_at': {
+        'type': 'str',
+        'default': '',
+        'label': 'Photos Disk Usage — Last Reconciled (internal)',
+        'category': 'Internal',
+        'description': (
+            'ISO timestamp of the most recent ground-truth reconciliation '
+            'walk written by manage.py purge-all.'
+        ),
+    },
 }
 
 # Ordered list of categories for the admin settings page.

--- a/manage.py
+++ b/manage.py
@@ -1388,6 +1388,27 @@ def purge_all(_args):
             print(f'admin_activity_log: ERROR {exc}')
             errors += 1
 
+    # Phase 26.5 (#36) — reconcile the cached photo-directory total
+    # against the on-disk truth. Upload / delete bumps keep the cache
+    # in step with live writes (cheap O(1) vs an os.walk on every
+    # /metrics scrape), but a missed bump or out-of-band file change
+    # would otherwise drift forever. Running this here bounds the
+    # staleness window to the purge-all cadence (typically 24 h).
+    try:
+        from app.services.photos import _photo_storage_total_bytes
+        from app.services.settings_svc import _upsert, invalidate_cache
+
+        photo_dir = app.config.get('PHOTO_STORAGE', '')
+        truth = _photo_storage_total_bytes(photo_dir)
+        ts = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
+        _upsert(conn, 'photos_disk_usage_bytes', str(truth))
+        _upsert(conn, 'photos_disk_usage_updated_at', ts)
+        invalidate_cache()
+        print(f'photos_disk_usage: reconciled to {truth} bytes ({photo_dir or "(unset)"})')
+    except Exception as exc:  # noqa: BLE001
+        print(f'photos_disk_usage: ERROR {exc}')
+        errors += 1
+
     conn.commit()
     conn.close()
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -435,6 +435,194 @@ def test_record_successful_login_emits_success_outcome(clean_metrics_registry, t
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Photo disk-usage gauge — Phase 26.5 (#36) cached scrape
+# ---------------------------------------------------------------------------
+#
+# The /metrics scrape used to walk the entire photo directory on every
+# Prometheus tick. The Phase 26.5 cache flips that to:
+#
+#   * upload / delete bumps `photos_disk_usage_bytes` by the file-size
+#     delta (cheap O(variants))
+#   * /metrics reads the cached value (O(1))
+#   * `manage.py purge-all` reconciles to ground truth daily
+#
+# These tests lock in the cached read, the upload/delete bookkeeping,
+# and the fresh-install fall-back walk.
+
+
+def _build_test_jpeg(width=400, height=300):
+    """Return a small valid JPEG byte stream for upload tests."""
+    import io
+
+    from PIL import Image
+
+    img = Image.new('RGB', (width, height), color='blue')
+    buf = io.BytesIO()
+    img.save(buf, format='JPEG', quality=85)
+    buf.seek(0)
+    return buf
+
+
+def _get_photo_disk_usage_bytes():
+    """Read the photos disk-usage gauge directly off the route's binding.
+
+    ``app.routes.metrics`` imports ``disk_usage_bytes`` at module-load
+    and writes via that reference forever. When other tests run the
+    ``clean_metrics_registry`` fixture (registry reset + module
+    reload), ``app.services.metrics.disk_usage_bytes`` becomes a fresh
+    gauge instance but the route's binding stays on the original
+    one. Reading from the route's binding is therefore the only
+    reliable way to see what the scrape just wrote.
+    """
+    from app.routes import metrics as _metrics_route
+
+    return _metrics_route.disk_usage_bytes._values.get(('photos',), 0)
+
+
+def test_metrics_disk_usage_reflects_upload_then_delete(app, client):
+    """Upload a photo, scrape, expect the gauge to match the on-disk delta.
+    Delete the photo, scrape again, expect the gauge to drop back to zero.
+
+    Locks in the bidirectional bookkeeping (upload bumps up, delete
+    bumps down) plus the cache-vs-walk consistency check.
+    """
+    import os
+
+    from werkzeug.datastructures import FileStorage
+
+    from app.services.photos import (
+        _photo_storage_total_bytes,
+        delete_photo_file,
+        process_upload,
+    )
+
+    _enable_metrics(app, networks='127.0.0.0/8')
+
+    photo_dir = app.config['PHOTO_STORAGE']
+    os.makedirs(photo_dir, exist_ok=True)
+
+    with app.app_context():
+        storage = FileStorage(_build_test_jpeg(), filename='test.jpg', content_type='image/jpeg')
+        result = process_upload(storage)
+    assert isinstance(result, dict), f'process_upload returned: {result!r}'
+
+    expected = _photo_storage_total_bytes(photo_dir)
+    assert expected > 0, 'no bytes landed on disk'
+
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    gauge = _get_photo_disk_usage_bytes()
+    assert gauge == expected, f'gauge {gauge} should equal on-disk total {expected} after upload'
+
+    with app.app_context():
+        delete_photo_file(result['storage_name'])
+
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    gauge_after = _get_photo_disk_usage_bytes()
+    assert gauge_after == 0, f'gauge {gauge_after} should be 0 after delete'
+
+
+def test_metrics_uses_cached_value_not_directory_walk(app, client, monkeypatch):
+    """Once the cache is populated, /metrics scrapes never walk the photo tree.
+
+    Pre-populates the cache, replaces the walk helper with a sentinel
+    that increments a counter on call, and asserts the counter stays
+    at zero across multiple scrapes. Regression guard for the whole
+    point of Phase 26.5: O(1) scrape regardless of photo count.
+    """
+    import sqlite3
+
+    _enable_metrics(app, networks='127.0.0.0/8')
+
+    # Pre-populate the cache to a non-zero value so /metrics serves it
+    # without falling back to the walk path.
+    conn = sqlite3.connect(app.config['DATABASE_PATH'])
+    conn.execute(
+        'INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)',
+        ('photos_disk_usage_bytes', '987654'),
+    )
+    conn.commit()
+    conn.close()
+    from app.services.settings_svc import invalidate_cache
+
+    invalidate_cache()
+
+    walk_calls = {'count': 0}
+
+    def _spy_walk(photo_dir):
+        walk_calls['count'] += 1
+        return 0
+
+    monkeypatch.setattr('app.services.photos._photo_storage_total_bytes', _spy_walk)
+
+    for _ in range(3):
+        response = client.get('/metrics')
+        assert response.status_code == 200
+        gauge = _get_photo_disk_usage_bytes()
+        assert gauge == 987654, f'expected cached 987654, got {gauge}'
+
+    assert walk_calls['count'] == 0, (
+        f'directory walk was called {walk_calls["count"]} times — '
+        'the whole point of the cache is to skip it on the hot path'
+    )
+
+
+def test_metrics_fresh_install_walks_once_then_caches(app, client):
+    """A fresh install with zero cache walks once on first scrape, writes
+    the result, and serves the cache on every subsequent scrape.
+
+    Confirms the fall-back path actually populates the setting so the
+    next scrape is O(1).
+    """
+    import io
+    import os
+    import sqlite3
+
+    from PIL import Image
+
+    _enable_metrics(app, networks='127.0.0.0/8')
+
+    # Drop any cached row from the test fixture's defaults so we exercise
+    # the fresh-install branch (cached==0).
+    conn = sqlite3.connect(app.config['DATABASE_PATH'])
+    conn.execute("DELETE FROM settings WHERE key = 'photos_disk_usage_bytes'")
+    conn.commit()
+    conn.close()
+    from app.services.settings_svc import invalidate_cache
+
+    invalidate_cache()
+
+    # Write one photo file directly (no upload pipeline, so no bump
+    # touches the cache — this is the "out-of-band file appeared"
+    # scenario the fall-back is for).
+    photo_dir = app.config['PHOTO_STORAGE']
+    os.makedirs(photo_dir, exist_ok=True)
+    img = Image.new('RGB', (50, 50), color='green')
+    out = os.path.join(photo_dir, 'manual-fixture.jpg')
+    buf = io.BytesIO()
+    img.save(buf, format='JPEG')
+    with open(out, 'wb') as f:
+        f.write(buf.getvalue())
+    expected = os.path.getsize(out)
+
+    # First scrape: cache is empty, code path walks once and writes back.
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    gauge = _get_photo_disk_usage_bytes()
+    assert gauge == expected, f'first-scrape gauge {gauge} != on-disk {expected}'
+
+    # Cache should now hold the walked value.
+    conn = sqlite3.connect(app.config['DATABASE_PATH'])
+    row = conn.execute(
+        'SELECT value FROM settings WHERE key = ?', ('photos_disk_usage_bytes',)
+    ).fetchone()
+    conn.close()
+    assert row is not None, 'fresh-install fall-back should have written the cache'
+    assert int(row[0]) == expected, f'cache write was {row[0]!r}, expected {expected}'
+
+
 def test_check_lockout_when_locked_emits_locked_outcome(clean_metrics_registry, tmp_path):
     """A locked-out attempt increments the locked counter exactly once."""
     import sqlite3


### PR DESCRIPTION
## Summary

- The `resume_site_disk_usage_bytes{path="photos"}` gauge previously walked the entire photo directory on every Prometheus scrape — multiple seconds per scrape at 10 k photos. `/metrics` now reads a cached `photos_disk_usage_bytes` setting in O(1).
- Photo upload / delete bump the value by the file-size delta (primary file + responsive variants); `manage.py purge-all` reconciles to a ground-truth walk so steady-state drift is bounded by the purge cadence (typically 24 h). Fresh installs fall back to a one-time walk on first scrape, then cache.
- DB-size half stays as `os.stat()` — already O(1) and always-fresh.
- Two new internal-only settings (`photos_disk_usage_bytes`, `photos_disk_usage_updated_at`); not surfaced in the admin UI.

## Test plan

- [x] `python -m pytest tests/test_metrics.py -x -v` — all 36 tests pass (3 new).
- [x] `python -m pytest tests/test_metrics.py tests/test_photo_processing.py tests/test_admin.py -x` — 96 pass.
- [x] Full suite: `python -m pytest tests/ --ignore=tests/loadtests --ignore=tests/synthetic -x` — 1340 pass.
- [x] `ruff check` + `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)