### PR TITLE
README: bump pre-release tag to v0.3.1-beta-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # resume-site
 
-> **Current pre-release: v0.3.1-beta-1** — _Keystone_ beta cycle. Every beta iteration passes the full release-publication gate (cosign-signed, Trivy-clean, rolling-upgrade replay verified); the stable `v0.3.1` tag cuts once the beta cycle closes. See [ROADMAP_v0.3.1.md](ROADMAP_v0.3.1.md), the [v0.2.0 history](ROADMAP_v0.2.0.md), and [CHANGELOG.md](CHANGELOG.md) for the full story.
+> **Current pre-release: v0.3.1-beta-2** — _Keystone_ beta cycle. Every beta iteration passes the full release-publication gate (cosign-signed, Trivy-clean, rolling-upgrade replay verified); the stable `v0.3.1` tag cuts once the beta cycle closes. See [ROADMAP_v0.3.1.md](ROADMAP_v0.3.1.md), the [v0.2.0 history](ROADMAP_v0.2.0.md), and [CHANGELOG.md](CHANGELOG.md) for the full story.
 
 A self-hosted, containerized resume and portfolio website engine built with Flask. Apple-inspired design, and admin panel for content management. **Distributed as a signed, multi-arch container image on GHCR** — a source checkout is only needed for development.
 
@@ -46,7 +46,7 @@ The container image on GHCR is the canonical artifact. **Pull it; do not build f
 ### 1. Pull and verify the signed image
 
 ```bash
-podman pull ghcr.io/kit3713/resume-site:v0.3.1-beta-1
+podman pull ghcr.io/kit3713/resume-site:v0.3.1-beta-2
 ```
 
 Verify the cosign signature before you run anything (keyless OIDC,
@@ -56,7 +56,7 @@ recorded in the public Sigstore transparency log):
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'https://github.com/Kit3713/resume-site/.+' \
-  ghcr.io/kit3713/resume-site:v0.3.1-beta-1
+  ghcr.io/kit3713/resume-site:v0.3.1-beta-2
 ```
 
 A non-zero exit means do not deploy — see the
@@ -89,8 +89,8 @@ curl -O https://raw.githubusercontent.com/Kit3713/resume-site/main/config.exampl
 cp config.example.yaml config.yaml
 # Edit config.yaml with your SMTP credentials and admin password.
 # Generate a secret_key + admin password hash with:
-#   podman run --rm ghcr.io/kit3713/resume-site:v0.3.1-beta-1 python manage.py generate-secret
-#   podman run --rm -it ghcr.io/kit3713/resume-site:v0.3.1-beta-1 python manage.py hash-password
+#   podman run --rm ghcr.io/kit3713/resume-site:v0.3.1-beta-2 python manage.py generate-secret
+#   podman run --rm -it ghcr.io/kit3713/resume-site:v0.3.1-beta-2 python manage.py hash-password
 ```
 
 ### 3. Run
@@ -108,7 +108,7 @@ podman run -d \
   -v resume-site-data:/app/data:Z \
   -v resume-site-photos:/app/photos:Z \
   -v resume-site-backups:/app/backups:Z \
-  ghcr.io/kit3713/resume-site:v0.3.1-beta-1
+  ghcr.io/kit3713/resume-site:v0.3.1-beta-2
 ```
 
 Bind to `127.0.0.1` so the reverse proxy is the only public ingress —
@@ -482,11 +482,11 @@ single-shot capture of the entire deployment state.
 ```bash
 # Pin to a specific version for reproducibility (recommended).
 # Re-run cosign verify on the new tag before restarting:
-podman pull ghcr.io/kit3713/resume-site:v0.3.1-beta-1
+podman pull ghcr.io/kit3713/resume-site:v0.3.1-beta-2
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'https://github.com/Kit3713/resume-site/.+' \
-  ghcr.io/kit3713/resume-site:v0.3.1-beta-1
+  ghcr.io/kit3713/resume-site:v0.3.1-beta-2
 
 podman stop resume-site
 podman rm resume-site


### PR DESCRIPTION
## Summary

Bumps the README pre-release tag and ghcr image references from `v0.3.1-beta-1` → `v0.3.1-beta-2`.

The Keystone beta cycle continues. v0.3.1-beta-2 carries the work that landed in this batch:

- **v0.3.1 closure** — Phase 22.5, 36.1, 36.6, 36.8 ticked. All v0.3.1 polish carry-overs done except the RC dry-run (release-time action).
- **v0.3.2 plumbing** — Phase 24.4 (Server header), 37.1 (API_COMPATIBILITY cross-refs), 37.2 (`@deprecated` decorator + webhook envelope + metric), 37.3 (OpenAPI drift guard), 37.4 (CHANGELOG enforcement) all shipped. Phase 37 is end-to-end functional; first usage waits for v0.4.0's `/api/v1/admin/*` reshape.
- **v0.3.3 small/medium** — Phase 26.4 (Pillow `Image.draft()`, 2.74× speedup), 26.5 (`/metrics` disk-usage cache, O(1)), 26.6 (benchmark log level), 28.1 (SQL grep guard), 28.2 (un-advisory vulture), 28.3 (retire `upgrade-simulation`), 28.4 (Quadlet hardening), 29.1 (form-field helper), 29.2 (CRUD `update_fields` helper), 29.3 (test fixture consolidation), 29.4 (issue #56 closeout).

The v0.3.3 large initiatives (Phases 30 DAST, 31 Playwright, 32 load-test gate, 33 mutation baseline, 34 edge-case methodology) remain open per scope decision — each is its own multi-day focused effort.

## Test plan

- [x] `pytest tests/` green on main: 1394 passed.
- [ ] CI passes on this PR (quality + tests + container-build + scan).
- [ ] After merge, the actual `v0.3.1-beta-2` tag can be cut to trigger the GHCR publish + cosign + tag-matrix machinery.