### PR TITLE
Post-merge fixups: drop stub @deprecated; benchmark secret_key

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -54,10 +54,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import os
-from datetime import UTC, date, datetime
-from functools import wraps
 
 from flask import (
     Blueprint,
@@ -65,7 +62,6 @@ from flask import (
     current_app,
     g,
     jsonify,
-    make_response,
     render_template,
     request,
 )
@@ -105,8 +101,8 @@ from app.services.blog import (
     unpublish_post,
     update_post,
 )
-from app.services.deprecation import (  # Phase 37.2 — plumbing imported; no route flagged yet
-    deprecated,  # noqa: F401
+from app.services.deprecation import (
+    deprecated,  # Phase 37.2 — plumbing imported; no route flagged yet  # noqa: F401
 )
 from app.services.form import get_stripped
 from app.services.pagination import clamp_page, offset_for, paginate
@@ -213,112 +209,6 @@ def _enforce_json_content_type():
             details={'received': ctype or 'missing'},
         )
     return None
-
-
-# ---------------------------------------------------------------------------
-# @deprecated decorator (Phase 37.2 stub — full impl per ROADMAP_v0.3.2.md)
-# ---------------------------------------------------------------------------
-#
-# Stub implementation pending the full Phase 37.2 landing. Accepts the
-# documented kwargs (``sunset_date``, ``replacement``, ``reason``) and does
-# the load-bearing pieces the test suite exercises in Phase 37.3:
-#
-#   * Sets ``Deprecation: true`` (RFC 9745 draft) on the response.
-#   * Sets ``Sunset: <HTTP-date>`` (RFC 8594) from ``sunset_date``.
-#   * Sets ``Link: <replacement>; rel="successor-version"`` when given.
-#   * Emits an INFO log on the ``app.api.deprecation`` logger with the
-#     request id, endpoint, user-agent, and optional ``X-Client-ID``.
-#   * Sets a ``__deprecated_sunset__`` attribute on the wrapped function so
-#     the OpenAPI drift-guard test can match the spec's ``x-sunset`` key.
-#
-# Idempotent across decorator stacking: if the response already carries the
-# headers (a stacked decorator ran first), we don't overwrite them.
-
-_DEPRECATION_LOGGER = logging.getLogger('app.api.deprecation')
-
-
-def _coerce_sunset_to_http_date(sunset_date):
-    """Render ``sunset_date`` as an RFC 7231 / RFC 8594 HTTP-date string."""
-    if isinstance(sunset_date, str):
-        # Accept ISO 8601 inputs (``2026-12-31`` or ``2026-12-31T00:00:00Z``)
-        # and re-emit in HTTP-date form so the Sunset header is RFC-compliant.
-        try:
-            parsed = datetime.fromisoformat(sunset_date.replace('Z', '+00:00'))
-        except ValueError:
-            return sunset_date  # caller's problem — surface as-is
-    elif isinstance(sunset_date, datetime):
-        parsed = sunset_date
-    elif isinstance(sunset_date, date):
-        parsed = datetime(sunset_date.year, sunset_date.month, sunset_date.day)
-    else:
-        return str(sunset_date)
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed.strftime('%a, %d %b %Y %H:%M:%S GMT')
-
-
-def _normalise_sunset_iso(sunset_date):
-    """Render ``sunset_date`` as a plain ``YYYY-MM-DD`` string for marker comparison."""
-    if isinstance(sunset_date, datetime):
-        return sunset_date.date().isoformat()
-    if isinstance(sunset_date, date):
-        return sunset_date.isoformat()
-    if isinstance(sunset_date, str):
-        try:
-            parsed = datetime.fromisoformat(sunset_date.replace('Z', '+00:00'))
-            return parsed.date().isoformat()
-        except ValueError:
-            return sunset_date
-    return str(sunset_date)
-
-
-def deprecated(sunset_date, replacement=None, reason=None):
-    """Mark an API route as deprecated.
-
-    Adds ``Deprecation`` / ``Sunset`` / ``Link`` response headers and logs
-    the call at INFO on the ``app.api.deprecation`` logger. Idempotent
-    across decorator stacking — already-set headers are preserved.
-
-    Args:
-        sunset_date: ``datetime.date`` / ``datetime.datetime`` / ISO 8601 str.
-            The removal date, surfaced in the ``Sunset`` HTTP header.
-        replacement: Optional URL of the successor endpoint, surfaced as
-            ``Link: <url>; rel="successor-version"``.
-        reason: Optional human-readable note logged alongside the call.
-    """
-    sunset_http = _coerce_sunset_to_http_date(sunset_date)
-    sunset_iso = _normalise_sunset_iso(sunset_date)
-
-    def _decorator(view):
-        @wraps(view)
-        def _wrapped(*args, **kwargs):
-            response = make_response(view(*args, **kwargs))
-            if 'Deprecation' not in response.headers:
-                response.headers['Deprecation'] = 'true'
-            if 'Sunset' not in response.headers:
-                response.headers['Sunset'] = sunset_http
-            if replacement and 'Link' not in response.headers:
-                response.headers['Link'] = f'<{replacement}>; rel="successor-version"'
-            # request_id is auto-injected by app.services.logging filter; the
-            # remaining context lives in extras so the JSON formatter picks
-            # it up alongside request_id / client_ip_hash for free.
-            _DEPRECATION_LOGGER.info(
-                'deprecated API call: endpoint=%s',
-                request.endpoint or view.__name__,
-                extra={
-                    'user_agent': request.headers.get('User-Agent', '-'),
-                    'client_id': request.headers.get('X-Client-ID', '-'),
-                    'reason': reason or '-',
-                },
-            )
-            return response
-
-        _wrapped.__deprecated_sunset__ = sunset_iso
-        _wrapped.__deprecated_replacement__ = replacement
-        _wrapped.__deprecated_reason__ = reason
-        return _wrapped
-
-    return _decorator
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/deprecation.py
+++ b/app/services/deprecation.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import functools
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from email.utils import format_datetime
 
 from flask import g, has_request_context, make_response, request
@@ -33,20 +33,34 @@ from app.services.metrics import deprecated_api_calls_total
 _log = logging.getLogger('app.api.deprecation')
 
 
-def _to_http_date(sunset_date: str) -> str:
-    """Convert an ISO ``YYYY-MM-DD`` date to an RFC 7231 HTTP-date.
+def _to_http_date(sunset_date: str | date | datetime) -> str:
+    """Convert a sunset date to an RFC 7231 HTTP-date.
 
     Uses ``email.utils.format_datetime`` rather than ``strftime('%a, %d
     %b %Y ...')`` so the day / month names are emitted in the C locale
     regardless of the host's ``LC_TIME`` setting — the HTTP spec
     requires English abbreviations.
     """
-    parsed = datetime.strptime(sunset_date, '%Y-%m-%d').replace(tzinfo=UTC)
+    if isinstance(sunset_date, datetime):
+        parsed = sunset_date if sunset_date.tzinfo else sunset_date.replace(tzinfo=UTC)
+    elif isinstance(sunset_date, date):
+        parsed = datetime(sunset_date.year, sunset_date.month, sunset_date.day, tzinfo=UTC)
+    else:
+        parsed = datetime.strptime(sunset_date, '%Y-%m-%d').replace(tzinfo=UTC)
     return format_datetime(parsed, usegmt=True)
 
 
+def _to_iso_date(sunset_date: str | date | datetime) -> str:
+    """Render the sunset as a plain ``YYYY-MM-DD`` string for marker comparison."""
+    if isinstance(sunset_date, datetime):
+        return sunset_date.date().isoformat()
+    if isinstance(sunset_date, date):
+        return sunset_date.isoformat()
+    return sunset_date
+
+
 def deprecated(
-    sunset_date: str,
+    sunset_date: str | date | datetime,
     *,
     replacement: str | None = None,
     reason: str | None = None,
@@ -84,6 +98,7 @@ def deprecated(
     composition accidentally produces a stack.
     """
     sunset_http_date = _to_http_date(sunset_date)
+    sunset_iso = _to_iso_date(sunset_date)
 
     def _decorator(view):
         endpoint_name = getattr(view, '__name__', '<view>')
@@ -125,6 +140,12 @@ def deprecated(
             deprecated_api_calls_total.inc(label_values=(endpoint_name,))
             return response
 
+        # Markers consumed by the OpenAPI drift-guard test (Phase 37.3) so the
+        # spec's ``deprecated: true`` + ``x-sunset`` keys can be cross-checked
+        # against the actual decorator on the route.
+        _wrapped.__deprecated_sunset__ = sunset_iso
+        _wrapped.__deprecated_replacement__ = replacement
+        _wrapped.__deprecated_reason__ = reason
         return _wrapped
 
     return _decorator

--- a/scripts/benchmark_routes.py
+++ b/scripts/benchmark_routes.py
@@ -67,7 +67,7 @@ def _write_test_config(tmp_path: Path) -> Path:
     )
     config_path = tmp_path / 'config.yaml'
     config_path.write_text(
-        'secret_key: "benchmark-key"\n'
+        'secret_key: "benchmark-key-32-chars-or-more-aaaaaaaa"\n'
         f'database_path: "{db_path}"\n'
         f'photo_storage: "{photos_path}"\n'
         'session_cookie_secure: false\n'


### PR DESCRIPTION
## Summary

Three issues uncovered after the v0.3.1-beta-2 batch (PRs #93–#120, #131) landed:

1. **F811 redefinition of `deprecated`** — `app/routes/api.py` shipped a stub decorator (PR #116, Phase 37.3) because PR #115 (Phase 37.2) hadn't merged when #116's worker ran. Once both landed, the stub clashed with the real import. CI quality job failed on `Ruff lint` blocking everything downstream. Stub removed; the real impl in `app/services/deprecation.py` is now the only definition.

2. **`@deprecated` ignored `date` / `datetime` inputs** — the real decorator only accepted ISO strings, but the regression test (`tests/test_api.py::test_deprecated_endpoint_emits_three_headers_and_logs`) calls `@deprecated(sunset_date=date(2027, 1, 15), …)`. The OpenAPI drift-guard test (`tests/test_openapi_spec.py`) also reads `__deprecated_sunset__` / `__deprecated_replacement__` / `__deprecated_reason__` markers on the wrapper. Decorator extended: accepts `str | date | datetime`, sets all three markers.

3. **Benchmark seed `secret_key` was 13 chars** — `scripts/benchmark_routes.py` carried `secret_key: "benchmark-key"`, which fails the v0.3.2 Phase 23.4 fatal validator (≥ 32 chars). Bumped to a 40-char placeholder so the benchmark can actually boot the app. Pre-existing; surfaced when Phase 26.6 (#107) tried to run the benchmark.

## Test plan

- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `pytest tests/test_deprecation.py tests/test_openapi_spec.py tests/test_api.py -x` — 163 passed.
- [x] Full suite: 1394 passed in 113s.