### PR TITLE
README: correct pre-release tag to v0.3.3-beta-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # resume-site
 
-> **Current pre-release: v0.3.1-beta-2** — _Keystone_ beta cycle. Every beta iteration passes the full release-publication gate (cosign-signed, Trivy-clean, rolling-upgrade replay verified); the stable `v0.3.1` tag cuts once the beta cycle closes. See [ROADMAP_v0.3.1.md](ROADMAP_v0.3.1.md), the [v0.2.0 history](ROADMAP_v0.2.0.md), and [CHANGELOG.md](CHANGELOG.md) for the full story.
+> **Current pre-release: v0.3.3-beta-1** — _Proof_ beta cycle. Every beta iteration passes the full release-publication gate (cosign-signed, Trivy-clean, rolling-upgrade replay verified); the stable `v0.3.3` tag cuts once the beta cycle closes. See [ROADMAP_v0.3.3.md](ROADMAP_v0.3.3.md) (current — Performance + CI hygiene + redundancy closeout shipped; DAST/Playwright/load-test/mutation/edge-case carry-overs still open), [ROADMAP_v0.3.2.md](ROADMAP_v0.3.2.md) (Shield — closed at beta-11 except the deferred items), [ROADMAP_v0.3.1.md](ROADMAP_v0.3.1.md) (Keystone — closed except the RC dry-run release-time action), the [v0.2.0 history](ROADMAP_v0.2.0.md), and [CHANGELOG.md](CHANGELOG.md) for the full story.
 
 A self-hosted, containerized resume and portfolio website engine built with Flask. Apple-inspired design, and admin panel for content management. **Distributed as a signed, multi-arch container image on GHCR** — a source checkout is only needed for development.
 
@@ -46,7 +46,7 @@ The container image on GHCR is the canonical artifact. **Pull it; do not build f
 ### 1. Pull and verify the signed image
 
 ```bash
-podman pull ghcr.io/kit3713/resume-site:v0.3.1-beta-2
+podman pull ghcr.io/kit3713/resume-site:v0.3.3-beta-1
 ```
 
 Verify the cosign signature before you run anything (keyless OIDC,
@@ -56,7 +56,7 @@ recorded in the public Sigstore transparency log):
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'https://github.com/Kit3713/resume-site/.+' \
-  ghcr.io/kit3713/resume-site:v0.3.1-beta-2
+  ghcr.io/kit3713/resume-site:v0.3.3-beta-1
 ```
 
 A non-zero exit means do not deploy — see the
@@ -89,8 +89,8 @@ curl -O https://raw.githubusercontent.com/Kit3713/resume-site/main/config.exampl
 cp config.example.yaml config.yaml
 # Edit config.yaml with your SMTP credentials and admin password.
 # Generate a secret_key + admin password hash with:
-#   podman run --rm ghcr.io/kit3713/resume-site:v0.3.1-beta-2 python manage.py generate-secret
-#   podman run --rm -it ghcr.io/kit3713/resume-site:v0.3.1-beta-2 python manage.py hash-password
+#   podman run --rm ghcr.io/kit3713/resume-site:v0.3.3-beta-1 python manage.py generate-secret
+#   podman run --rm -it ghcr.io/kit3713/resume-site:v0.3.3-beta-1 python manage.py hash-password
 ```
 
 ### 3. Run
@@ -108,7 +108,7 @@ podman run -d \
   -v resume-site-data:/app/data:Z \
   -v resume-site-photos:/app/photos:Z \
   -v resume-site-backups:/app/backups:Z \
-  ghcr.io/kit3713/resume-site:v0.3.1-beta-2
+  ghcr.io/kit3713/resume-site:v0.3.3-beta-1
 ```
 
 Bind to `127.0.0.1` so the reverse proxy is the only public ingress —
@@ -482,11 +482,11 @@ single-shot capture of the entire deployment state.
 ```bash
 # Pin to a specific version for reproducibility (recommended).
 # Re-run cosign verify on the new tag before restarting:
-podman pull ghcr.io/kit3713/resume-site:v0.3.1-beta-2
+podman pull ghcr.io/kit3713/resume-site:v0.3.3-beta-1
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'https://github.com/Kit3713/resume-site/.+' \
-  ghcr.io/kit3713/resume-site:v0.3.1-beta-2
+  ghcr.io/kit3713/resume-site:v0.3.3-beta-1
 
 podman stop resume-site
 podman rm resume-site


### PR DESCRIPTION
## Summary

The README had drifted: it claimed `v0.3.1-beta-1` as the current pre-release, but actual release history is at `v0.3.2-beta-11` (2026-04-24) with `v0.3.3-beta` already tagged. PR #131 bumped to `v0.3.1-beta-2` based on the stale README, which reverses the version order.

This PR sets the README to `v0.3.3-beta-1` — the natural next iteration on top of the existing `v0.3.3-beta` marker. Carries the v0.3.1 + v0.3.2 + v0.3.3 work that landed in the recent batch (PRs #93-#120, #131, #135).

## Changes

- Headline "Current pre-release" line → `v0.3.3-beta-1` with cross-references to all three roadmaps and a status note (Proof cycle, what's shipped, what's still open).
- All `podman pull` / `cosign verify` / `podman run` example tags → `v0.3.3-beta-1`.
- Tag-matrix example table left untouched — `v0.3.1` there is an illustrative format example, not a current-version claim.

## Next step (after merge)

Tag `v0.3.3-beta-1` at `main` and push. The publish job in `ci.yml` will build, scan, sign with cosign, and push the multi-arch image to GHCR. `release-verify` smoke-tests amd64+arm64.