### PR TITLE
Phase 34.2: edge-case retroactive pass — blog admin

### DIFF
--- a/tests/test_edge_cases_blog_admin.py
+++ b/tests/test_edge_cases_blog_admin.py
@@ -1,0 +1,845 @@
+"""
+Edge-case tests for the blog admin surface — Phase 34.2.
+
+Targets ``/admin/blog`` and its sibling HTML routes — ``/admin/blog/new``,
+``/admin/blog/<id>/edit``, ``/admin/blog/<id>/delete`` — and the workflow
+actions exposed through the edit form (publish / unpublish / archive).
+Public-facing edge cases live in ``tests/test_edge_cases_blog.py``; this
+file covers the *admin* surface only.
+
+Organised by the 7-category checklist in ``tests/TESTING_STANDARDS.md``
+plus two surface-specific groupings (pagination — Phase 26.3 #54 — and
+the publish/draft/archive workflow). Slug/race fixes from #139/#140 are
+exercised under ``TestConcurrency``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_post(
+    auth_client,
+    title='Test Post',
+    summary='A test post',
+    content='<p>Test content with enough words for reading time.</p>',
+    tags='',
+    action='save',
+    **kwargs,
+):
+    """Create a blog post via the admin form and return the response."""
+    data = {
+        'title': title,
+        'summary': summary,
+        'content': content,
+        'content_format': 'html',
+        'cover_image': '',
+        'author': 'Test Author',
+        'tags': tags,
+        'meta_description': '',
+        'action': action,
+        **kwargs,
+    }
+    return auth_client.post('/admin/blog/new', data=data, follow_redirects=False)
+
+
+_EDIT_DEFAULTS = {
+    'title': 'Untitled',
+    'summary': '',
+    'content': '<p>body</p>',
+    'content_format': 'html',
+    'cover_image': '',
+    'author': '',
+    'tags': '',
+    'meta_description': '',
+    'slug': '',
+    'action': 'save',
+}
+
+
+def _edit_post(auth_client, post_id, **fields):
+    """POST to the edit form, filling required fields with safe defaults."""
+    data = {**_EDIT_DEFAULTS, **fields}
+    return auth_client.post(f'/admin/blog/{post_id}/edit', data=data, follow_redirects=False)
+
+
+def _db_conn(app):
+    """Open a raw SQLite connection with row access by column name."""
+    conn = sqlite3.connect(app.config['DATABASE_PATH'])
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _post_id_by_title(app, title):
+    conn = _db_conn(app)
+    try:
+        row = conn.execute(
+            'SELECT id FROM blog_posts WHERE title = ? ORDER BY id DESC LIMIT 1',
+            (title,),
+        ).fetchone()
+        return row['id'] if row else None
+    finally:
+        conn.close()
+
+
+def _post_by_id(app, post_id):
+    conn = _db_conn(app)
+    try:
+        return conn.execute('SELECT * FROM blog_posts WHERE id = ?', (post_id,)).fetchone()
+    finally:
+        conn.close()
+
+
+def _count_posts(app):
+    conn = sqlite3.connect(app.config['DATABASE_PATH'])
+    try:
+        return conn.execute('SELECT COUNT(*) FROM blog_posts').fetchone()[0]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_post(auth_client, app):
+    """Create a single saved-as-draft post and return (post_id, slug)."""
+    _create_post(auth_client, title='Seed Post')
+    post_id = _post_id_by_title(app, 'Seed Post')
+    row = _post_by_id(app, post_id)
+    return post_id, row['slug']
+
+
+# ===========================================================================
+# 1. Empty / null inputs
+# ===========================================================================
+
+
+class TestEmptyAndNull:
+    """Empty string, whitespace, null bytes — every required field path."""
+
+    def test_create_rejects_empty_title(self, auth_client):
+        response = _create_post(auth_client, title='')
+        assert response.status_code == 200
+        assert b'Title is required' in response.data or b'required' in response.data
+
+    def test_create_rejects_whitespace_only_title(self, auth_client):
+        response = _create_post(auth_client, title='   \t\n  ')
+        assert response.status_code == 200
+        # Form re-renders (no redirect)
+        assert b'Title is required' in response.data or b'required' in response.data
+
+    def test_edit_rejects_empty_title_persists_no_change(self, auth_client, app, seeded_post):
+        post_id, original_slug = seeded_post
+        before = _post_by_id(app, post_id)
+        response = _edit_post(auth_client, post_id, title='')
+        assert response.status_code == 200  # re-renders form, not 302
+        after = _post_by_id(app, post_id)
+        # Title was not overwritten; slug unchanged
+        assert after['title'] == before['title']
+        assert after['slug'] == original_slug
+
+    def test_create_with_empty_content_accepted(self, auth_client, app):
+        """An empty body is allowed — only title is required."""
+        response = _create_post(auth_client, title='No Body', content='')
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'No Body')
+        row = _post_by_id(app, post_id)
+        assert row['content'] == ''
+        assert row['reading_time'] == 0
+
+    def test_create_with_empty_tags_persists_no_associations(self, auth_client, app):
+        response = _create_post(auth_client, title='No Tags', tags='')
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'No Tags')
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            row = conn.execute(
+                'SELECT COUNT(*) FROM blog_post_tags WHERE post_id = ?',
+                (post_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == 0
+
+    def test_create_null_byte_in_title_does_not_crash(self, auth_client, app):
+        """Null bytes embedded mid-title must not 500 or break SQLite binding."""
+        response = _create_post(auth_client, title='Hello\x00World')
+        # SQLite TEXT columns accept embedded NULs; the route must not crash.
+        assert response.status_code in (200, 302)
+        # No row should have a literal '\x00' that would corrupt the slug index
+        # (slugify drops non-word chars, so the slug is the safe 'helloworld').
+        if response.status_code == 302:
+            # If accepted, verify the row landed cleanly
+            rows = _count_posts(app)
+            assert rows >= 1
+
+
+# ===========================================================================
+# 2. Boundary / length
+# ===========================================================================
+
+
+class TestLengthBoundaries:
+    """Single-char, max-realistic, oversized — title, body, slug, tag."""
+
+    def test_single_character_title_accepted(self, auth_client, app):
+        response = _create_post(auth_client, title='a')
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'a')
+        assert _post_by_id(app, post_id)['slug'] == 'a'
+
+    def test_title_at_500_chars_persists(self, auth_client, app):
+        long_title = 'Word ' * 100  # 500 chars
+        response = _create_post(auth_client, title=long_title)
+        assert response.status_code == 302
+        # No length cap on TEXT — verify the row landed
+        assert _count_posts(app) == 1
+
+    def test_large_body_accepted(self, auth_client, app):
+        """~400 KB body via the admin form (Flask default ``MAX_FORM_MEMORY_SIZE``
+        is 500 KB so we stay well under). Must not 500."""
+        large = '<p>' + ('x' * (400 * 1024)) + '</p>'
+        response = _create_post(auth_client, title='Large Body', content=large)
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'Large Body')
+        # Reading time still computable
+        assert _post_by_id(app, post_id)['reading_time'] >= 1
+
+    def test_oversized_body_returns_413(self, auth_client):
+        """Bodies past ``MAX_FORM_MEMORY_SIZE`` (default 500 KB) are rejected
+        by Werkzeug's parser before the route runs — 413 is the contract."""
+        huge = '<p>' + ('x' * (1 << 20)) + '</p>'
+        response = _create_post(auth_client, title='Too Big', content=huge)
+        assert response.status_code == 413
+
+    def test_slug_at_realistic_max_length(self, auth_client, app, seeded_post):
+        """A 200-char manual slug round-trips through the edit path cleanly."""
+        post_id, _ = seeded_post
+        long_slug = 'a' * 200
+        response = _edit_post(auth_client, post_id, title='Seed Post', slug=long_slug)
+        assert response.status_code == 302
+        assert _post_by_id(app, post_id)['slug'] == long_slug
+
+    def test_very_many_tags(self, auth_client, app):
+        """100 distinct tags on a single post — junction table must hold."""
+        tag_list = ','.join(f'tag{i:03d}' for i in range(100))
+        response = _create_post(auth_client, title='Tagged Hard', tags=tag_list)
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'Tagged Hard')
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            count = conn.execute(
+                'SELECT COUNT(*) FROM blog_post_tags WHERE post_id = ?',
+                (post_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 100
+
+    def test_very_long_individual_tag(self, auth_client, app):
+        """A 500-char single tag must not break parsing of the comma list."""
+        long_tag = 'x' * 500
+        response = _create_post(auth_client, title='Long Tag', tags=f'{long_tag}, short')
+        assert response.status_code == 302
+
+
+# ===========================================================================
+# 3. Type mismatch / coercion
+# ===========================================================================
+
+
+class TestTypeMismatch:
+    """Boolean coercion, status enum coercion, page parameter coercion."""
+
+    @pytest.mark.parametrize('value', ['on', '1', 'true', 'yes'])
+    def test_featured_truthy_string_values_coerce(self, auth_client, app, value):
+        """HTML form ``featured`` is presence-based; any non-empty string wins."""
+        response = _create_post(auth_client, title=f'F-{value}', featured=value)
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, f'F-{value}')
+        assert _post_by_id(app, post_id)['featured'] == 1
+
+    def test_featured_unchecked_means_zero(self, auth_client, app):
+        """When the checkbox isn't checked the form key is absent."""
+        # _create_post doesn't add 'featured' unless asked — confirm default 0
+        response = _create_post(auth_client, title='Not Featured')
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'Not Featured')
+        assert _post_by_id(app, post_id)['featured'] == 0
+
+    def test_invalid_content_format_rejected_on_create(self, auth_client):
+        """Phase 27.4 (#24) — content_format must be html or markdown."""
+        response = _create_post(auth_client, title='Bogus Format', content_format='garbage')
+        assert response.status_code == 200
+        assert b'content_format' in response.data or b'Invalid' in response.data
+
+    def test_invalid_content_format_on_edit_does_not_persist(self, auth_client, app, seeded_post):
+        """Phase 27.4 (#24) — invalid content_format on edit must not write a
+        bogus value to the row. The current edit-path implementation hits an
+        ``UnboundLocalError`` rendering the re-displayed form (``tags_str``
+        is referenced before assignment in the rejection branch), so the
+        actual status code is 500. What's load-bearing is that the bogus
+        value does NOT land in the DB — pin that contract.
+        """
+        post_id, _ = seeded_post
+        response = _edit_post(auth_client, post_id, title='Seed Post', content_format='garbage')
+        # Today: 500 from the UnboundLocalError; aspirational: 200 with
+        # re-rendered form. Either way the bogus value must NOT persist.
+        assert response.status_code in (200, 500)
+        assert _post_by_id(app, post_id)['content_format'] == 'html'
+
+    def test_content_format_case_sensitive(self, auth_client):
+        """``HTML`` (upper) is NOT in the allowlist; must be rejected."""
+        response = _create_post(auth_client, title='Case', content_format='HTML')
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        'bad_page',
+        ['not-a-number', '-1', '0', 'abc', '1.5', '∞', '🚀', '   '],
+    )
+    def test_pagination_bad_page_falls_back_to_1(self, auth_client, bad_page):
+        """Phase 26.3 — non-numeric or non-positive ``?page=`` -> page 1."""
+        response = auth_client.get(f'/admin/blog?page={bad_page}')
+        assert response.status_code == 200
+
+    def test_pagination_negative_page_clamps_to_1(self, auth_client):
+        response = auth_client.get('/admin/blog?page=-5')
+        assert response.status_code == 200
+
+    def test_status_filter_unknown_value_treated_as_no_filter(self, auth_client, app):
+        """Unknown ``?status=`` strings fall through to "show all"."""
+        _create_post(auth_client, title='Visible', action='save')
+        response = auth_client.get('/admin/blog?status=garbage')
+        assert response.status_code == 200
+        # The draft post should still be visible (filter was discarded)
+        assert b'Visible' in response.data
+
+
+# ===========================================================================
+# 4. Unicode
+# ===========================================================================
+
+
+class TestUnicode:
+    """Multi-byte titles + slugs + body content; combining marks; emoji."""
+
+    @pytest.mark.parametrize(
+        'title',
+        [
+            'Café Résumé',  # accented Latin
+            '日本語のブログ',  # CJK
+            '🚀 Launch 🚀',  # emoji
+            'أهلاً بالعالم',  # Arabic (RTL)
+            'שלום עולם',  # Hebrew (RTL)
+            'éclipse',  # combining acute
+            'a‍z',  # zero-width joiner
+        ],
+    )
+    def test_unicode_title_admin_create_succeeds(self, auth_client, app, title):
+        response = _create_post(auth_client, title=title)
+        assert response.status_code == 302
+        # Title is stored verbatim; slug is whatever slugify produces.
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            row = conn.execute(
+                'SELECT title, slug FROM blog_posts ORDER BY id DESC LIMIT 1'
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == title.strip() or row[0] == title
+
+    def test_unicode_body_persists(self, auth_client, app):
+        body = '<p>Héllo 🌍 日本語 שלום</p>'
+        response = _create_post(auth_client, title='Unicode Body', content=body)
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'Unicode Body')
+        stored = _post_by_id(app, post_id)['content']
+        # nh3 keeps the unicode characters intact even though it sanitises HTML
+        assert '🌍' in stored
+        assert '日本語' in stored
+
+    def test_unicode_tags_persisted(self, auth_client, app):
+        response = _create_post(auth_client, title='Unicode Tags', tags='日本語, café, 🚀launch')
+        assert response.status_code == 302
+        # The slugified tags must still produce non-empty slugs OR be dropped
+        # (slugify can return '' for some Unicode-only inputs). Either way the
+        # admin form must not 500.
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            tag_rows = conn.execute('SELECT name, slug FROM blog_tags').fetchall()
+        finally:
+            conn.close()
+        # At least the latin/café tag should land with a non-empty slug
+        slugs = [r[1] for r in tag_rows]
+        assert all(s for s in slugs), f'empty tag slug snuck in: {tag_rows!r}'
+
+    def test_combining_marks_in_title_do_not_break_slug(self, auth_client, app):
+        """e + COMBINING ACUTE must produce a deterministic slug."""
+        title = 'café vs café'  # NFC vs NFD form of 'café'
+        response = _create_post(auth_client, title=title)
+        assert response.status_code == 302
+
+
+# ===========================================================================
+# 5. Injection
+# ===========================================================================
+
+
+class TestInjection:
+    """HTML/JS, template, path-traversal, null-byte payloads via the form."""
+
+    def test_script_tag_in_body_stripped_by_sanitizer(self, auth_client, app):
+        response = _create_post(
+            auth_client,
+            title='XSS body',
+            content='<p>safe</p><script>alert(1)</script>',
+        )
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'XSS body')
+        stored = _post_by_id(app, post_id)['content']
+        assert '<script' not in stored.lower()
+        assert 'alert(1)' not in stored
+
+    def test_event_handler_in_body_stripped(self, auth_client, app):
+        response = _create_post(
+            auth_client,
+            title='Event Handler',
+            content='<img src=x onerror="alert(1)">',
+        )
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'Event Handler')
+        stored = _post_by_id(app, post_id)['content']
+        assert 'onerror' not in stored.lower()
+
+    def test_javascript_url_stripped(self, auth_client, app):
+        response = _create_post(
+            auth_client,
+            title='JS URL',
+            content='<a href="javascript:alert(1)">x</a>',
+        )
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'JS URL')
+        stored = _post_by_id(app, post_id)['content']
+        assert 'javascript:' not in stored.lower()
+
+    def test_iframe_in_body_stripped(self, auth_client, app):
+        response = _create_post(
+            auth_client,
+            title='Iframe',
+            content='<p>ok</p><iframe src="http://evil"></iframe>',
+        )
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, 'Iframe')
+        stored = _post_by_id(app, post_id)['content']
+        assert '<iframe' not in stored.lower()
+
+    def test_template_braces_in_title_not_evaluated(self, auth_client, app):
+        """``{{ 7*7 }}`` in a title must persist as literal text, never as 49.
+
+        Jinja2 escapes via autoescape so the braces show up verbatim in the
+        rendered output rather than being interpreted as an expression. The
+        load-bearing assertion is that ``49`` is NOT in the rendered page.
+        """
+        response = _create_post(auth_client, title='{{ 7*7 }} probe')
+        assert response.status_code == 302
+        post_id = _post_id_by_title(app, '{{ 7*7 }} probe')
+        assert post_id is not None
+        view = auth_client.get(f'/admin/blog/{post_id}/edit')
+        assert view.status_code == 200
+        body = view.get_data(as_text=True)
+        # Template injection would replace '{{ 7*7 }}' with '49' — absence
+        # of '49 probe' proves the expression was not evaluated.
+        assert '49 probe' not in body
+        # The literal "{{ 7*7 }}" survives (escaped or as text in input value)
+        assert '7*7' in body
+
+    def test_jinja_statement_in_title_not_evaluated(self, auth_client, app):
+        """``{% raw %}`` style block tags must be inert."""
+        response = _create_post(auth_client, title='{% if True %}HACK{% endif %}')
+        # The WAF doesn't block these patterns, and SQLite-binding strips
+        # them of any code-execution semantics. Just confirm the row lands.
+        assert response.status_code == 302
+
+    def test_sql_metacharacters_in_title_safe(self, auth_client, app):
+        """Bare apostrophes pass the WAF and rely on parameterized queries."""
+        response = _create_post(auth_client, title="O'Brien's Latest Post -- a thought")
+        assert response.status_code == 302
+        # Schema still intact (would fail if SQL ran)
+        assert _count_posts(app) >= 1
+
+    def test_sql_injection_in_form_body_safe_via_parameterized_queries(self, auth_client, app):
+        """The WAF body-scan (#84) regex doesn't URL-decode form data so the
+        ``;`` in ``Robert'); DROP TABLE`` becomes ``%3B`` and slips past the
+        ``;\\s*(DROP)`` fingerprint. Parameterized queries still hold the
+        line — the post saves as a literal title and the schema is intact.
+        """
+        response = _create_post(auth_client, title="Robert'); DROP TABLE blog_posts;--")
+        # Form-urlencoded SQLi survives the WAF; the DB layer is the
+        # final defense and it holds because we use ? placeholders.
+        assert response.status_code in (302, 400)
+        # blog_posts table still exists with the new row
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            count = conn.execute('SELECT COUNT(*) FROM blog_posts').fetchone()[0]
+        finally:
+            conn.close()
+        assert count >= 0  # didn't drop the table
+
+    def test_path_traversal_in_slug_rejected_or_safe(self, auth_client, app, seeded_post):
+        """``../../etc/passwd`` as a slug must not escape the slugify pipe."""
+        post_id, _ = seeded_post
+        response = _edit_post(auth_client, post_id, title='Seed Post', slug='../../etc/passwd')
+        # The slugify pipe strips '/' and '.' chars so the result is safe.
+        # We assert the slug landed without traversal metacharacters.
+        if response.status_code == 302:
+            stored_slug = _post_by_id(app, post_id)['slug']
+            assert '/' not in stored_slug
+            assert '..' not in stored_slug
+
+    def test_crlf_in_title_does_not_split_response(self, auth_client, app):
+        """CRLF in the title must not enable response-splitting downstream."""
+        response = _create_post(auth_client, title='Hello\r\nX-Evil: yes')
+        assert response.status_code == 302
+        # No X-Evil header in the redirect response itself
+        assert 'X-Evil' not in response.headers
+
+
+# ===========================================================================
+# 6. Slug edge cases — specific to the admin slug input field on edit
+# ===========================================================================
+
+
+class TestSlugBoundaries:
+    """Empty, reserved, collision, unicode, numeric-only slug inputs."""
+
+    def test_empty_slug_falls_back_to_title_based(self, auth_client, app, seeded_post):
+        """Empty slug field on edit -> slugify(title) is used."""
+        post_id, _ = seeded_post
+        response = _edit_post(auth_client, post_id, title='New Title For Slug', slug='')
+        assert response.status_code == 302
+        # slugify('New Title For Slug') -> 'new-title-for-slug'
+        assert _post_by_id(app, post_id)['slug'] == 'new-title-for-slug'
+
+    def test_slug_collision_gets_numeric_suffix(self, auth_client, app):
+        """When admin sets slug to an already-used value, suffix appends."""
+        _create_post(auth_client, title='First')  # slug=first
+        _create_post(auth_client, title='Second')  # slug=second
+        second_id = _post_id_by_title(app, 'Second')
+        response = _edit_post(auth_client, second_id, title='Second', slug='first')
+        assert response.status_code == 302
+        final = _post_by_id(app, second_id)['slug']
+        assert final != 'first'
+        assert final.startswith('first-')
+
+    def test_keeping_own_slug_on_edit_no_collision(self, auth_client, app, seeded_post):
+        """Editing a post and keeping its own slug must not self-collide."""
+        post_id, original_slug = seeded_post
+        response = _edit_post(auth_client, post_id, title='Seed Post', slug=original_slug)
+        assert response.status_code == 302
+        assert _post_by_id(app, post_id)['slug'] == original_slug
+
+    @pytest.mark.parametrize('reserved', ['new', 'edit', 'delete', 'admin'])
+    def test_reserved_slug_values_accepted_but_routed_correctly(
+        self, auth_client, app, seeded_post, reserved
+    ):
+        """The admin lets you set slug to "new" or "edit". Because the public
+        blog route is ``/blog/<slug>`` and admin routes live under
+        ``/admin/blog/...``, reserved-word slugs aren't actually shadowed.
+        Pin this contract: the post saves successfully."""
+        post_id, _ = seeded_post
+        response = _edit_post(auth_client, post_id, title='Seed Post', slug=reserved)
+        assert response.status_code == 302
+        # The slug we get back is the slugified form of the input.
+        assert _post_by_id(app, post_id)['slug'] == reserved
+
+    def test_numeric_only_slug_accepted(self, auth_client, app, seeded_post):
+        """``2024`` is a valid slug per slugify."""
+        post_id, _ = seeded_post
+        response = _edit_post(auth_client, post_id, title='Seed Post', slug='2024')
+        assert response.status_code == 302
+        assert _post_by_id(app, post_id)['slug'] == '2024'
+
+    def test_unicode_slug_input_gets_slugified(self, auth_client, app, seeded_post):
+        """``Café Spécial`` -> ``cafe-special`` per slugify."""
+        post_id, _ = seeded_post
+        response = _edit_post(auth_client, post_id, title='Seed Post', slug='Café Spécial!')
+        assert response.status_code == 302
+        new_slug = _post_by_id(app, post_id)['slug']
+        # slugify lowercases and drops non-word chars; details vary by impl
+        # but the slug must be non-empty and lowercase.
+        assert new_slug
+        assert new_slug == new_slug.lower()
+        assert ' ' not in new_slug
+        assert '!' not in new_slug
+
+
+# ===========================================================================
+# 7. Pagination edge cases — Phase 26.3 (#54)
+# ===========================================================================
+
+
+class TestPagination:
+    """Page param boundaries, status-filter composition, very large pages."""
+
+    def test_page_zero_clamps_to_1(self, auth_client):
+        _create_post(auth_client, title='Single')
+        response = auth_client.get('/admin/blog?page=0')
+        assert response.status_code == 200
+        assert b'Single' in response.data
+
+    def test_page_at_very_large_number_renders(self, auth_client):
+        """A page well past the last must render an empty table, not 500."""
+        _create_post(auth_client, title='Only Post')
+        response = auth_client.get('/admin/blog?page=999999')
+        assert response.status_code == 200
+
+    def test_page_equals_last_page(self, auth_client, app):
+        """26 posts -> last page is 2 (25 + 1)."""
+        for i in range(26):
+            _create_post(auth_client, title=f'Post {i:02d}')
+        response = auth_client.get('/admin/blog?page=2')
+        assert response.status_code == 200
+
+    def test_page_one_past_last_page_renders_empty(self, auth_client, app):
+        """26 posts -> page 3 is past the end; must still render."""
+        for i in range(26):
+            _create_post(auth_client, title=f'P{i:02d}')
+        response = auth_client.get('/admin/blog?page=3')
+        assert response.status_code == 200
+
+    def test_status_filter_composes_with_page(self, auth_client, app):
+        """Filter draft + page=1 must succeed and show only draft posts."""
+        _create_post(auth_client, title='Draft One', action='save')
+        _create_post(auth_client, title='Pub One', action='publish')
+        response = auth_client.get('/admin/blog?status=draft&page=1')
+        assert response.status_code == 200
+        assert b'Draft One' in response.data
+        assert b'Pub One' not in response.data
+
+    def test_invalid_status_filter_dropped(self, auth_client):
+        """Whitelist enforces draft/published/archived only."""
+        _create_post(auth_client, title='X')
+        response = auth_client.get('/admin/blog?status=DRAFT')  # case-sensitive
+        # The route's allowlist is lowercase only; uppercase falls to None.
+        assert response.status_code == 200
+        assert b'X' in response.data  # still shown because filter dropped
+
+    def test_negative_page_with_filter(self, auth_client):
+        _create_post(auth_client, title='A', action='publish')
+        response = auth_client.get('/admin/blog?status=published&page=-99')
+        assert response.status_code == 200
+        assert b'A' in response.data
+
+
+# ===========================================================================
+# 8. Publish / draft / archive workflow
+# ===========================================================================
+
+
+class TestWorkflowTransitions:
+    """State machine: draft <-> published <-> archived. Idempotency too."""
+
+    def test_publish_nonexistent_post_returns_404_or_redirect(self, auth_client):
+        """Editing a post that doesn't exist -> flash + redirect, no crash."""
+        response = auth_client.post(
+            '/admin/blog/999999/edit',
+            data={
+                'title': 'x',
+                'content': 'x',
+                'content_format': 'html',
+                'action': 'publish',
+            },
+            follow_redirects=False,
+        )
+        # The route flashes 'Post not found' and redirects to the list
+        assert response.status_code in (302, 404)
+
+    def test_publish_already_published_post_idempotent(self, auth_client, app):
+        """Re-publishing must keep the original published_at timestamp."""
+        _create_post(auth_client, title='Once', action='publish')
+        post_id = _post_id_by_title(app, 'Once')
+        first = _post_by_id(app, post_id)
+        original_published_at = first['published_at']
+        assert original_published_at is not None
+
+        # Re-publish via edit -> publish action
+        _edit_post(auth_client, post_id, title='Once', action='publish')
+        after = _post_by_id(app, post_id)
+        assert after['status'] == 'published'
+        assert after['published_at'] == original_published_at
+
+    def test_unpublish_returns_to_draft(self, auth_client, app):
+        _create_post(auth_client, title='Pubbed', action='publish')
+        post_id = _post_id_by_title(app, 'Pubbed')
+        _edit_post(auth_client, post_id, title='Pubbed', action='unpublish')
+        assert _post_by_id(app, post_id)['status'] == 'draft'
+
+    def test_archive_from_published(self, auth_client, app):
+        _create_post(auth_client, title='ToArc', action='publish')
+        post_id = _post_id_by_title(app, 'ToArc')
+        _edit_post(auth_client, post_id, title='ToArc', action='archive')
+        assert _post_by_id(app, post_id)['status'] == 'archived'
+
+    def test_draft_to_publish_to_archive_to_draft_round_trip(self, auth_client, app):
+        """All valid transitions must round-trip without losing the row."""
+        _create_post(auth_client, title='RT')
+        post_id = _post_id_by_title(app, 'RT')
+        assert _post_by_id(app, post_id)['status'] == 'draft'
+
+        _edit_post(auth_client, post_id, title='RT', action='publish')
+        assert _post_by_id(app, post_id)['status'] == 'published'
+
+        _edit_post(auth_client, post_id, title='RT', action='archive')
+        assert _post_by_id(app, post_id)['status'] == 'archived'
+
+        # Archived -> draft via unpublish? No — the route only sets draft
+        # via the explicit 'unpublish' action. Unpublishing an archived
+        # post brings it back to draft (status update is unconditional).
+        _edit_post(auth_client, post_id, title='RT', action='unpublish')
+        assert _post_by_id(app, post_id)['status'] == 'draft'
+
+    def test_unknown_action_falls_back_to_save(self, auth_client, app):
+        """An unknown ``action`` value must not crash — falls through to save."""
+        _create_post(auth_client, title='Stay')
+        post_id = _post_id_by_title(app, 'Stay')
+        before_status = _post_by_id(app, post_id)['status']
+        response = _edit_post(auth_client, post_id, title='Stay', action='garbage')
+        assert response.status_code == 302
+        # Status unchanged — the 'else' branch in the route is a plain save
+        assert _post_by_id(app, post_id)['status'] == before_status
+
+    def test_delete_nonexistent_post_returns_redirect(self, auth_client):
+        """Deleting a missing post must not 500."""
+        response = auth_client.post('/admin/blog/999999/delete', follow_redirects=False)
+        # Route is tolerant — delete_post is a no-op for missing rows
+        assert response.status_code == 302
+
+
+# ===========================================================================
+# 9. Concurrency — #139 / #140 race fixes
+# ===========================================================================
+
+
+class TestConcurrency:
+    """Race-conditioned writes through the admin form path."""
+
+    def test_update_after_post_deleted_raises_cleanly(self, app, auth_client):
+        """#140 — stale form: post deleted between page load and POST.
+
+        ``update_post`` raises ``ValueError`` on UPDATE rowcount==0 so that
+        no orphan junction rows land. The route doesn't catch it, so a
+        500 is the documented contract — what matters is the DB state
+        afterward is consistent (no orphan blog_post_tags).
+        """
+        _create_post(auth_client, title='Vanishing')
+        post_id = _post_id_by_title(app, 'Vanishing')
+        # Simulate deletion-by-other-admin between load and save
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            conn.execute('DELETE FROM blog_posts WHERE id = ?', (post_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Now POST the stale edit form. The route checks get_post_by_id
+        # *before* update_post, so it flashes and redirects.
+        response = auth_client.post(
+            f'/admin/blog/{post_id}/edit',
+            data={
+                'title': 'Anything',
+                'content': '<p>x</p>',
+                'content_format': 'html',
+                'tags': 'tag1,tag2',
+                'action': 'save',
+            },
+            follow_redirects=False,
+        )
+        # Either redirect (post-not-found flash) or 500 from update_post —
+        # both are documented. What MUST hold: no orphan junction rows.
+        assert response.status_code in (302, 500)
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            orphans = conn.execute(
+                'SELECT COUNT(*) FROM blog_post_tags WHERE post_id = ?',
+                (post_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert orphans == 0, '#140: orphan tag rows leaked'
+
+    def test_concurrent_creates_unique_at_db_level(self, app, auth_client):
+        """#139 — concurrent admin POSTs with the same title must all land
+        as distinct rows with distinct slugs.
+
+        The test extracts ground-truth from the DB after the burst (the
+        UNIQUE(slug) constraint guarantees no two rows share a slug),
+        rather than reading per-thread response bodies, which gives a
+        consistent, race-free check. The contract is: every successful
+        2xx/3xx response corresponds to a DB row, and every row has a
+        unique slug.
+        """
+        errors: list[BaseException] = []
+        successes: list[int] = []
+        lock = threading.Lock()
+
+        def create():
+            try:
+                with app.test_client() as client:
+                    with client.session_transaction() as sess:
+                        sess['_user_id'] = 'admin'
+                        sess['_fresh'] = True
+                        sess['_admin_epoch'] = 0
+                    response = client.post(
+                        '/admin/blog/new',
+                        data={
+                            'title': 'Race Same',
+                            'summary': '',
+                            'content': '<p>x</p>',
+                            'content_format': 'html',
+                            'cover_image': '',
+                            'author': '',
+                            'tags': '',
+                            'meta_description': '',
+                            'action': 'save',
+                        },
+                        follow_redirects=False,
+                    )
+                    if response.status_code == 302:
+                        with lock:
+                            successes.append(response.status_code)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=create) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f'race raised: {errors!r}'
+        # All successful creates produced distinct rows with distinct slugs
+        conn = sqlite3.connect(app.config['DATABASE_PATH'])
+        try:
+            rows = conn.execute("SELECT slug FROM blog_posts WHERE title = 'Race Same'").fetchall()
+        finally:
+            conn.close()
+        slugs = [r[0] for r in rows]
+        # UNIQUE(slug) constraint guarantees this; if it ever fails the
+        # retry loop in create_post regressed.
+        assert len(slugs) == len(set(slugs)), (
+            f'duplicate slugs slipped past UNIQUE constraint: {slugs!r}'
+        )
+        # And every successful response corresponds to a row.
+        assert len(rows) == len(successes), (
+            f'response count {len(successes)} != row count {len(rows)}'
+        )


### PR DESCRIPTION
## Summary

Phase 34.2 of the v0.3.3 "Proof" roadmap — edge-case retroactive pass for the blog admin surface. Adds `tests/test_edge_cases_blog_admin.py` with **76 tests** across 9 class-grouped categories covering `/admin/blog`, `/admin/blog/new`, `/admin/blog/<id>/edit`, `/admin/blog/<id>/delete`, and the publish/draft/archive workflow.

- Coverage of `app/routes/blog_admin.py` rises to **95.6%**.
- Coverage of `app/services/blog.py` (admin-touching paths only) rises to **67.2%**.
- Public/API edge cases stay in `tests/test_edge_cases_blog.py` — no duplication.

## Test categories (per `tests/TESTING_STANDARDS.md`)

| Class | Coverage |
|---|---|
| `TestEmptyAndNull` | empty/whitespace title, null-byte title, empty body, empty tags |
| `TestLengthBoundaries` | single-char title, 500-char title, 400 KB body, 413 at >500 KB (Flask `MAX_FORM_MEMORY_SIZE`), 200-char slug, 100 distinct tags, 500-char individual tag |
| `TestTypeMismatch` | featured checkbox coercion, invalid `content_format` rejected (create+edit), case-sensitive `content_format`, parametrized bad `?page=` values, unknown `?status=` dropped |
| `TestUnicode` | parametrized titles (Latin/CJK/emoji/Arabic/Hebrew/combining/ZWJ), unicode body, unicode tags, combining-mark slug |
| `TestInjection` | `<script>`/`on*`/`javascript:`/`<iframe>` stripped; Jinja `{{...}}` not evaluated; SQLi via parameterized queries; CRLF in title; path-traversal in slug |
| `TestSlugBoundaries` | empty slug -> title-based, collision suffix, self-no-collide, reserved words (new/edit/delete/admin), numeric-only, unicode-input slugify |
| `TestPagination` (Phase 26.3 #54) | page=0, very-large page, page==last, page==last+1, filter+page compose, negative page with filter |
| `TestWorkflowTransitions` | publish non-existent (404/redirect), publish idempotency (preserves original `published_at`), unpublish→draft, archive, full round-trip, unknown action falls to save, delete non-existent |
| `TestConcurrency` (#139/#140) | update after deletion leaves zero orphan `blog_post_tags`; 4-thread same-title race produces distinct slugs at DB level |

## Latent bug pinned (not fixed in this PR)

`test_invalid_content_format_on_edit_does_not_persist` exposes an `UnboundLocalError` in `app/routes/blog_admin.py:196` — the invalid-`content_format` branch on the edit path references `tags_str` before assignment. The test asserts the bogus `content_format` value does NOT land in the DB while tolerating either the current 500 or the aspirational 200; a follow-up code fix can land without breaking this test.

## Test plan

- [x] `pytest tests/test_edge_cases_blog_admin.py -v` — 76/76 pass
- [x] `pytest tests/test_edge_cases_blog_admin.py --cov=app.routes.blog_admin --cov=app.services.blog` — 95.6% / 67.2%
- [x] `ruff check tests/test_edge_cases_blog_admin.py` — clean
- [x] `ruff format --check tests/test_edge_cases_blog_admin.py` — clean
- [x] `bandit -c pyproject.toml tests/test_edge_cases_blog_admin.py` — no issues
- [x] `vulture tests/test_edge_cases_blog_admin.py` — clean
- [ ] CI: full test suite green
- [ ] CI: ruff/bandit/vulture blocking checks green

Generated with [Claude Code](https://claude.com/claude-code)